### PR TITLE
Load cache from local or remote zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/*
 cache-old
 dumpFn
 cache
+cache.zip
 node_modules
 docs
 .npmrc

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "exports": "./src/index.js",
   "version": "1.0.0",
   "description": "Read Old-School Runescape Cache files",
-  "contributors": [
-    {
-      "name": "Dezinted",
-      "url": "https://github.com/Dezinater"
-    }
-  ],
+  "contributors": [{
+    "name" : "Dezinted",
+    "url" : "https://github.com/Dezinater"
+  }],
   "main": "./src/index",
   "type": "module",
   "files": [
@@ -34,11 +32,7 @@
     "path": false,
     "os": false
   },
-  "keywords": [
-    "old school runescape",
-    "osrs",
-    "cache reader"
-  ],
+  "keywords": ["old school runescape", "osrs", "cache reader"],
   "author": "",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "exports": "./src/index.js",
   "version": "1.0.0",
   "description": "Read Old-School Runescape Cache files",
-  "contributors": [{
-    "name" : "Dezinted",
-    "url" : "https://github.com/Dezinater"
-  }],
+  "contributors": [
+    {
+      "name": "Dezinted",
+      "url": "https://github.com/Dezinater"
+    }
+  ],
   "main": "./src/index",
   "type": "module",
   "files": [
@@ -32,7 +34,11 @@
     "path": false,
     "os": false
   },
-  "keywords": ["old school runescape", "osrs", "cache reader"],
+  "keywords": [
+    "old school runescape",
+    "osrs",
+    "cache reader"
+  ],
   "author": "",
   "license": "BSD-2-Clause",
   "bugs": {
@@ -55,8 +61,9 @@
     "browser-or-node": "^2.1.1",
     "bz2": "^1.0.1",
     "canvas": "^2.11.0",
+    "fflate": "^0.8.2",
     "gzip-js": "^0.3.2",
     "mocha": "^10.2.0",
-    "web-worker": "^1.2.0"
+    "web-worker": "~1.2.0"
   }
 }

--- a/src/cacheReader/CacheLoader.js
+++ b/src/cacheReader/CacheLoader.js
@@ -16,12 +16,26 @@ export default class CacheLoader {
         xteas: undefined,
     };
 
+    //cache promise is complete after all promises are setup
+    cachePromise;
+    cachePromiseResolve;
+
     constructor(path, onDownloadProgress) {
         this.onDownloadProgress = onDownloadProgress;
+        this.cachePromise = new Promise((resolve, reject) => {
+            this.cachePromiseResolve = resolve;
+        });
 
-        if (this.isValidHttpUrl(path) || isBrowser) {
+        if (path == "latest" || path == undefined) {    //load by current date
+            this.loadByTimestamp(new Date());
+        } else if (this.isValidHttpUrl(path)) {         //load by url
             this.fetchURL(path);
-        } else {
+        } else if (!isNaN(path)) {                      //load by version number
+            let version = Number(path);
+            this.loadByVersion(version);
+        } else if (path.prototype.name == "Date") {     //load by date
+            this.loadByTimestamp(path);
+        } else {                                        //load by local file path
             this.loadFile(path);
         }
 
@@ -29,6 +43,7 @@ export default class CacheLoader {
 
     getResults() {
         return new Promise(async resolve => {
+            await this.cachePromise;
             const datPromiseResults = await this.promises.datFile;
             const indexPromiseResults = await Promise.all(this.promises.indexFiles);
             const xteasResults = await this.promises.xteas;
@@ -55,9 +70,26 @@ export default class CacheLoader {
         const zip = zipBufferPromise.then(zip => unzipSync(new Uint8Array(zip)));
         this.promises.datFile = zip.then(dir => dir['cache/' + this.datFile]);
         this.promises.indexFiles = this.indexFiles.map((indexFile, i) => {
-            return zip.then(dir => dir['cache/' + indexFile]).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`)});
+            return zip.then(dir => dir['cache/' + indexFile]).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`) });
         });
         this.promises.xteas = zip.then(dir => dir['cache/xteas.json']).catch(e => { console.warn("Maps (Index 5) will not load without xteas.json") });
+    }
+
+    loadByVersion(version) {
+        axios.get("https://archive.openrs2.org/caches.json", { responseType: 'json' }).then(caches => {
+            let filtered = caches.data.filter(x => x.game == "oldschool" && x.builds.length > 0 && x.builds[0].major == version);
+            let sorted = filtered.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+            this.fetchURL(`https://archive.openrs2.org/caches/runescape/${sorted[0].id}/disk.zip`);
+        });
+    }
+
+    loadByTimestamp(timestamp) {
+        axios.get("https://archive.openrs2.org/caches.json", { responseType: 'json' }).then(caches => {
+            let filtered = caches.data.filter(x => x.game == "oldschool");
+            filtered.forEach(x => x.score = Math.abs(new Date(x.timestamp) - timestamp)); //rank them by distance
+            let sorted = filtered.sort((a, b) => a.score - b.score);
+            this.fetchURL(`https://archive.openrs2.org/caches/runescape/${sorted[0].id}/disk.zip`);
+        });
     }
 
     fetchURL(url) {
@@ -70,11 +102,13 @@ export default class CacheLoader {
 
             this.promises.datFile = axios.get(url + this.datFile, { onDownloadProgress: this.onDownloadProgress, responseType: 'arraybuffer', }).then(x => new Uint8Array(x.data));
             this.indexFiles.forEach((indexFile, i) => {
-                let indexPromise = axios.get(url + indexFile, { responseType: 'arraybuffer' }).then(x => new Uint8Array(x.data)).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`)});
+                let indexPromise = axios.get(url + indexFile, { responseType: 'arraybuffer' }).then(x => new Uint8Array(x.data)).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`) });
                 this.promises.indexFiles.push(indexPromise);
             });
             this.promises.xteas = axios.get(url + "xteas.json", { responseType: 'json', }).then(x => this.readXteas(x.data)).catch(e => { console.warn("Maps (Index 5) will not load without xteas.json") });
         }
+
+        this.cachePromiseResolve();
     }
 
     loadFile(path) {
@@ -104,6 +138,8 @@ export default class CacheLoader {
                 resolve(this.readXteas(data));
             }));
         }
+
+        this.cachePromiseResolve();
     }
 
     readXteas(xteasData) {

--- a/src/cacheReader/CacheLoader.js
+++ b/src/cacheReader/CacheLoader.js
@@ -26,16 +26,17 @@ export default class CacheLoader {
             this.cachePromiseResolve = resolve;
         });
 
-        if (path == "latest" || path == undefined) {    //load by current date
+        //this if statement needs to stay in this order or else there will be false positives
+        if (path == "latest" || path == undefined) {                                    //load by current date
             this.loadByTimestamp(new Date());
-        } else if (this.isValidHttpUrl(path)) {         //load by url
-            this.fetchURL(path);
-        } else if (!isNaN(path)) {                      //load by version number
+        } else if (path.constructor != undefined && path.constructor.name == "Date") {  //load by date
+            this.loadByTimestamp(path);
+        } else if (!isNaN(path)) {                                                      //load by version number
             let version = Number(path);
             this.loadByVersion(version);
-        } else if (path.prototype.name == "Date") {     //load by date
-            this.loadByTimestamp(path);
-        } else {                                        //load by local file path
+        } else if (this.isValidHttpUrl(path) || isBrowser) {                            //load by url
+            this.fetchURL(path);
+        } else {                                                                        //load by local file path
             this.loadFile(path);
         }
 

--- a/src/cacheReader/CacheLoader.js
+++ b/src/cacheReader/CacheLoader.js
@@ -2,6 +2,7 @@ import { isBrowser } from "browser-or-node";
 import axios from 'axios';
 import * as fs from "fs";
 import IndexType from "./cacheTypes/IndexType.js";
+import { unzipSync } from 'fflate';
 
 
 export default class CacheLoader {
@@ -50,42 +51,59 @@ export default class CacheLoader {
         return url.protocol === "http:" || url.protocol === "https:";
     }
 
+    handleZip(zipBufferPromise) {
+        const zip = zipBufferPromise.then(zip => unzipSync(new Uint8Array(zip)));
+        this.promises.datFile = zip.then(dir => dir['cache/' + this.datFile]);
+        this.promises.indexFiles = this.indexFiles.map((indexFile, i) => {
+            return zip.then(dir => dir['cache/' + indexFile]).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`)});
+        });
+        this.promises.xteas = zip.then(dir => dir['cache/xteas.json']).catch(e => { console.warn("Maps (Index 5) will not load without xteas.json") });
+    }
+
     fetchURL(url) {
         if (url.endsWith(".zip")) {
-            console.log("decompress zip file " + url);
-            return;
-        }
+            this.handleZip(axios.get(url, { responseType: 'arraybuffer' }).then(zip => zip.data));
+        } else {
+            if (!url.endsWith("/")) {
+                url += "/";
+            }
 
-        if (!url.endsWith("/")) {
-            url += "/";
+            this.promises.datFile = axios.get(url + this.datFile, { onDownloadProgress: this.onDownloadProgress, responseType: 'arraybuffer', }).then(x => new Uint8Array(x.data));
+            this.indexFiles.forEach((indexFile, i) => {
+                let indexPromise = axios.get(url + indexFile, { responseType: 'arraybuffer' }).then(x => new Uint8Array(x.data)).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`)});
+                this.promises.indexFiles.push(indexPromise);
+            });
+            this.promises.xteas = axios.get(url + "xteas.json", { responseType: 'json', }).then(x => this.readXteas(x.data)).catch(e => { console.warn("Maps (Index 5) will not load without xteas.json") });
         }
-
-        this.promises.datFile = axios.get(url + this.datFile, { onDownloadProgress: this.onDownloadProgress, responseType: 'arraybuffer', }).then(x => new Uint8Array(x.data));
-        this.indexFiles.forEach((indexFile, i) => {
-            let indexPromise = axios.get(url + indexFile, { responseType: 'arraybuffer' }).then(x => new Uint8Array(x.data)).catch(_ => { console.warn(`${IndexType.keyOf(i)} (Index ${i}) will not load without ${indexFile}`)});
-            this.promises.indexFiles.push(indexPromise);
-        });
-        this.promises.xteas = axios.get(url + "xteas.json", { responseType: 'json', }).then(x => this.readXteas(x.data)).catch(e => { console.warn("Maps (Index 5) will not load without xteas.json") });
     }
 
     loadFile(path) {
-        if (!path.endsWith("/")) {
-            path += "/";
+        if (path.endsWith(".zip")) {
+            const zip = new Promise((resolve, reject) => fs.readFile(path, (err, data) => {
+                if (err) throw err;
+                resolve(data)
+            }))
+            this.handleZip(zip)
+        } else {
+            if (!path.endsWith("/")) {
+                path += "/";
+            }
+
+            this.promises.datFile = new Promise((resolve, reject) => fs.readFile(path + this.datFile, (err, data) => {
+                if (err) throw err;
+                resolve(data)
+            }));
+            this.indexFiles.forEach(async indexFile => {
+                let newPromise = new Promise(resolve => fs.readFile(path + indexFile, (err, data) => resolve(data)));
+                this.promises.indexFiles.push(newPromise);
+            });
+
+            this.promises.xteas = new Promise((resolve, reject) => fs.readFile(path + "xteas.json", "utf8", (err, data) => {
+                // if (err) throw err;
+                if (err) resolve()
+                resolve(this.readXteas(data));
+            }));
         }
-
-        this.promises.datFile = new Promise((resolve, reject) => fs.readFile(path + this.datFile, (err, data) => {
-            if (err) throw err;
-            resolve(data)
-        }));
-        this.indexFiles.forEach(async indexFile => {
-            let newPromise = new Promise(resolve => fs.readFile(path + indexFile, (err, data) => resolve(data)));
-            this.promises.indexFiles.push(newPromise);
-        });
-
-        this.promises.xteas = new Promise((resolve, reject) => fs.readFile(path + "xteas.json", "utf8", (err, data) => {
-            if (err) throw err;
-            resolve(this.readXteas(data));
-        }));
     }
 
     readXteas(xteasData) {

--- a/src/cacheReader/RSCache.js
+++ b/src/cacheReader/RSCache.js
@@ -25,7 +25,7 @@ import ConfigType from './cacheTypes/ConfigType.js'
  * @param {function(number):void} progressFunc Progress function callback. Passes 1 parameter which is the amount of progress from the last step (not total progress)
  */
 class RSCache {
-	constructor(cacheRootDir = "./", progressFunc = () => { }) {
+	constructor(cacheRootDir, progressFunc = () => { }) {
 		this.indicies = {};
 		this.progressFunc = progressFunc;
 

--- a/src/cacheReader/RSCache.js
+++ b/src/cacheReader/RSCache.js
@@ -21,8 +21,29 @@ import ConfigType from './cacheTypes/ConfigType.js'
 /**
  * Creates a RSCache reader
  * @category Base
- * @param {string} cacheRootDir 
+ * @param {string} cacheRootDir This can either be a URL, local file path, version number, Date object, or the string 'latest'. If it is a URL or file path it should point to the root of the cache folder or a zip file containing a cache folder such as from https://archive.openrs2.org/
  * @param {function(number):void} progressFunc Progress function callback. Passes 1 parameter which is the amount of progress from the last step (not total progress)
+ * 
+ * @example <caption>Load by URL</caption>
+ * let cache = new RSCache("https://runemonk.com/cache/");
+ * 
+ * @example <caption>Load by URL Zip</caption>
+ * let cache = new RSCache("https://archive.openrs2.org/caches/runescape/1718/disk.zip");
+ * 
+ * @example <caption>Load by File Path</caption>
+ * let cache = new RSCache("./cache/");
+ * 
+ * @example <caption>Load by File Path Zip</caption>
+ * let cache = new RSCache("./cache.zip");
+ * 
+ * @example <caption>Load by Version Number</caption>
+ * let cache = new RSCache(220);
+ * 
+ * @example <caption>Load latest</caption>
+ * let cache = new RSCache('latest');
+ * 
+ * @example <caption>Load by Date</caption>
+ * let cache = new RSCache(new Date("Jan 1 2024"));
  */
 class RSCache {
 	constructor(cacheRootDir, progressFunc = () => { }) {

--- a/test/LoadNPC.spec.js
+++ b/test/LoadNPC.spec.js
@@ -9,6 +9,8 @@ describe('Load NPC', function () {
 
     before(function (done) {
         cache  = new RSCache("./cache");
+        // cache = new RSCache("./cache.zip");
+        // cache = new RSCache("https://archive.openrs2.org/caches/runescape/241/disk.zip");
         cache.onload.then(() => {
             done();
         });


### PR DESCRIPTION
Solves https://github.com/Dezinater/osrscachereader/issues/1
Added cache loading via downloading and unzipping remote and local zip files

Prevents https://github.com/Dezinater/osrscachereader/issues/3
Resolves undefined when the xteas file is not found, it crashed on my cache version

Pinned web-worker 1.2 since 1.3.0 gave me an error.

NOTE: package-lock.json not updated since prebuilt binaries for canvas are not available for ARM mac, and npm fails to build it. I succeeded with pnpm, but did not want to include that lock file, so you have to run npm i yourself after this PR