### PR TITLE
Improve GLTF export and add node script (`npm run model`) to export specific models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ cache
 cache.zip
 node_modules
 docs
+out
 .npmrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "useTabs": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "useTabs": true
+  "useTabs": false,
+  "tabWidth": 4
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "test": "mocha",
     "generate": "node scripts/generateAnimList.js & node scripts/generateAnimayaAnimList.js",
+    "model": "node scripts/dumpModel.js",
     "docs": "jsdoc -r ./src/ -t ./node_modules/better-docs -c ./jsdoc.json -d docs --readme ./README.md",
     "dev": "webpack serve --mode development",
     "devnode": "node src/index-dev-node.js"

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -4,25 +4,40 @@ import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 
 const DUMP_FRAMES = false;
 
-let cache = new RSCache("./cache");
-cache.onload.then(async () => {
-	console.log("Loaded");
-	//const npcId = 7706; // zuk
-	const npcId = 7698;
-	let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
+const npcsAndAnimations = [
+	{
+		npcId: 7706, // zuk
+		animations: [
+			7564, // idle
+			7566, // fire
+		],
+	},
+	{
+		npcId: 7698, // ranger
+		animations: [
+			7602, // idle
+			7603, // walk
+			7605, // fire
+		]
+	}
+];
 
-	// zuk idle
-	//const animId = 7564;
-	const animId = 7605;
-	for (let i = 0; i < npc.models.length; ++i) {
-		let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
+const processNpc = async ({npcId, animations}) => {
+let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
 
+for (let i = 0; i < npc.models.length; ++i) {
+	let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
+
+	const loadedFrames = [];
+	const loadedAnimations = [];
+	for (const animId of animations) {
 		const animationDef = await cache.getFile(
 			IndexType.CONFIGS.id,
 			ConfigType.SEQUENCE.id,
 			animId
 		);
 		let animation = animationDef.def;
+		loadedAnimations.push(animation);
 
 		let selectedAnimation = await cache.getFile(
 			IndexType.CONFIGS.id,
@@ -31,45 +46,57 @@ cache.onload.then(async () => {
 		);
 		let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
 		let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
+		loadedFrames.push(...frames);
+	}
 
-		const exporter = new GLTFExporter(model);
-		frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
-		exporter.addColors(model);
+	const exporter = new GLTFExporter(model);
+	loadedFrames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+	exporter.addColors(model);
+	loadedAnimations.forEach((animation) => {
 		exporter.addAnimation(animation);
+	});
 
-		const gltf = exporter.export();
+	const gltf = exporter.export();
 
-		const path = `./out/${npc.id}_${model.id}_${animation.id}.gltf`;
-		fs.writeFileSync(path, gltf);
-		console.log(`Wrote single file to ${path}`);
+	const path = `./out/${npc.id}_${model.id}.gltf`;
+	fs.writeFileSync(path, gltf);
+	console.log(`Wrote single file to ${path}`);
 
 
-		if (DUMP_FRAMES) {
-			let initialVertexPositionsX = model.vertexPositionsX;
-			let initialVertexPositionsY = model.vertexPositionsY;
-			let initialVertexPositionsZ = model.vertexPositionsZ;
+	if (DUMP_FRAMES) {
+		let initialVertexPositionsX = model.vertexPositionsX;
+		let initialVertexPositionsY = model.vertexPositionsY;
+		let initialVertexPositionsZ = model.vertexPositionsZ;
 
-			let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
-			for (const frame of frameDefs) {
-				model.vertexPositionsX = initialVertexPositionsX;
-				model.vertexPositionsY = initialVertexPositionsY;
-				model.vertexPositionsZ = initialVertexPositionsZ;
-				const loaded = model.loadFrame(model, frame);
-				model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
-				model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
-				model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
+		let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
+		for (const frame of frameDefs) {
+			model.vertexPositionsX = initialVertexPositionsX;
+			model.vertexPositionsY = initialVertexPositionsY;
+			model.vertexPositionsZ = initialVertexPositionsZ;
+			const loaded = model.loadFrame(model, frame);
+			model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
+			model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
+			model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
 
-				const exporter = new GLTFExporter(model);
-				//frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
-				//exporter.addAnimation(animation);
+			const exporter = new GLTFExporter(model);
+			//frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+			//exporter.addAnimation(animation);
 
-				const gltf = exporter.export();
+			const gltf = exporter.export();
 
-				const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
-				fs.writeFileSync(path, gltf);
-				console.log(`Wrote file to ${path}`);
-			}
+			const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
+			fs.writeFileSync(path, gltf);
+			console.log(`Wrote file to ${path}`);
 		}
+	}
+}
+};
+
+let cache = new RSCache("./cache");
+cache.onload.then(async () => {
+	console.log("Loaded");
+	for (const npc of npcsAndAnimations) {
+		await processNpc(npc);
 	}
 	cache.close();
 	return true;

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -2,16 +2,18 @@ import fs from "fs";
 
 import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 
+const DUMP_FRAMES = false;
+
 let cache = new RSCache("./cache");
 cache.onload.then(async () => {
 	console.log("Loaded");
-	const npcId = 7706; // zuk
-	//const npcId = 7698;
+	//const npcId = 7706; // zuk
+	const npcId = 7698;
 	let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
 
 	// zuk idle
-	const animId = 7564;
-	//const animId = 7605;
+	//const animId = 7564;
+	const animId = 7605;
 	for (let i = 0; i < npc.models.length; ++i) {
 		let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
 
@@ -30,12 +32,9 @@ cache.onload.then(async () => {
 		let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
 		let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
 
-		let initialVertexPositionsX = model.vertexPositionsX;
-		let initialVertexPositionsY = model.vertexPositionsY;
-		let initialVertexPositionsZ = model.vertexPositionsZ;
-
 		const exporter = new GLTFExporter(model);
 		frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+		exporter.addColors(model);
 		exporter.addAnimation(animation);
 
 		const gltf = exporter.export();
@@ -44,25 +43,32 @@ cache.onload.then(async () => {
 		fs.writeFileSync(path, gltf);
 		console.log(`Wrote single file to ${path}`);
 
-		let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
-		for (const frame of frameDefs) {
-			model.vertexPositionsX = initialVertexPositionsX;
-			model.vertexPositionsY = initialVertexPositionsY;
-			model.vertexPositionsZ = initialVertexPositionsZ;
-			const loaded = model.loadFrame(model, frame);
-			model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
-			model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
-			model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
 
-			const exporter = new GLTFExporter(model);
-			//frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
-			//exporter.addAnimation(animation);
+		if (DUMP_FRAMES) {
+			let initialVertexPositionsX = model.vertexPositionsX;
+			let initialVertexPositionsY = model.vertexPositionsY;
+			let initialVertexPositionsZ = model.vertexPositionsZ;
 
-			const gltf = exporter.export();
+			let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
+			for (const frame of frameDefs) {
+				model.vertexPositionsX = initialVertexPositionsX;
+				model.vertexPositionsY = initialVertexPositionsY;
+				model.vertexPositionsZ = initialVertexPositionsZ;
+				const loaded = model.loadFrame(model, frame);
+				model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
+				model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
+				model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
 
-			const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
-			fs.writeFileSync(path, gltf);
-			console.log(`Wrote file to ${path}`);
+				const exporter = new GLTFExporter(model);
+				//frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+				//exporter.addAnimation(animation);
+
+				const gltf = exporter.export();
+
+				const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
+				fs.writeFileSync(path, gltf);
+				console.log(`Wrote file to ${path}`);
+			}
 		}
 	}
 	cache.close();

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -5,99 +5,110 @@ import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 const DUMP_FRAMES = false;
 
 const npcsAndAnimations = [
-	{
-		npcId: 7706, // zuk
-		animations: [
-			7564, // idle
-			7566, // fire
-		],
-	},
-	{
-		npcId: 7698, // ranger
-		animations: [
-			7602, // idle
-			7603, // walk
-			7605, // fire
-		]
-	}
+    {
+        npcId: 7706, // zuk
+        animations: [
+            7564, // idle
+            7566, // fire
+        ],
+    },
+    {
+        npcId: 7698, // ranger
+        animations: [
+            7602, // idle
+            7603, // walk
+            7605, // fire
+        ],
+    },
+    {
+        npcId: 7699, // mager
+        animations: [
+            7609, // idle,
+            7608, // walk
+            7610, // mage fire
+        ],
+    },
 ];
 
-const processNpc = async ({npcId, animations}) => {
-let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
+const processNpc = async ({ npcId, animations }) => {
+    let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
 
-for (let i = 0; i < npc.models.length; ++i) {
-	let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
+    for (let i = 0; i < npc.models.length; ++i) {
+        let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
 
-	const loadedFrames = [];
-	const loadedAnimations = [];
-	for (const animId of animations) {
-		const animationDef = await cache.getFile(
-			IndexType.CONFIGS.id,
-			ConfigType.SEQUENCE.id,
-			animId
-		);
-		let animation = animationDef.def;
-		loadedAnimations.push(animation);
+        const loadedFrames = [];
+        const loadedAnimations = [];
+        for (const animId of animations) {
+            const animationDef = await cache.getFile(
+                IndexType.CONFIGS.id,
+                ConfigType.SEQUENCE.id,
+                animId
+            );
+            let animation = animationDef.def;
+            loadedAnimations.push(animation);
 
-		let selectedAnimation = await cache.getFile(
-			IndexType.CONFIGS.id,
-			ConfigType.SEQUENCE.id,
-			animId
-		);
-		let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
-		let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
-		loadedFrames.push(...frames);
-	}
+            let selectedAnimation = await cache.getFile(
+                IndexType.CONFIGS.id,
+                ConfigType.SEQUENCE.id,
+                animId
+            );
+            let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
+            let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
+            loadedFrames.push(...frames);
+        }
 
-	const exporter = new GLTFExporter(model);
-	loadedFrames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
-	exporter.addColors(model);
-	loadedAnimations.forEach((animation) => {
-		exporter.addAnimation(animation);
-	});
+        const exporter = new GLTFExporter(model);
+        loadedFrames.forEach((frame) =>
+            exporter.addMorphTarget(frame.vertices)
+        );
+        exporter.addColors(model);
+        loadedAnimations.forEach((animation) => {
+            exporter.addAnimation(animation);
+        });
 
-	const gltf = exporter.export();
+        const gltf = exporter.export();
 
-	const path = `./out/${npc.id}_${model.id}.gltf`;
-	fs.writeFileSync(path, gltf);
-	console.log(`Wrote single file to ${path}`);
+        const path = `./out/${npc.id}_${model.id}.gltf`;
+        fs.writeFileSync(path, gltf);
+        console.log(`Wrote single file to ${path}`);
 
+        if (DUMP_FRAMES) {
+            let initialVertexPositionsX = model.vertexPositionsX;
+            let initialVertexPositionsY = model.vertexPositionsY;
+            let initialVertexPositionsZ = model.vertexPositionsZ;
 
-	if (DUMP_FRAMES) {
-		let initialVertexPositionsX = model.vertexPositionsX;
-		let initialVertexPositionsY = model.vertexPositionsY;
-		let initialVertexPositionsZ = model.vertexPositionsZ;
+            let frameDefs = (
+                await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)
+            ).map((x) => x.def);
+            for (const frame of frameDefs) {
+                model.vertexPositionsX = initialVertexPositionsX;
+                model.vertexPositionsY = initialVertexPositionsY;
+                model.vertexPositionsZ = initialVertexPositionsZ;
+                const loaded = model.loadFrame(model, frame);
+                model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
+                model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
+                model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
 
-		let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
-		for (const frame of frameDefs) {
-			model.vertexPositionsX = initialVertexPositionsX;
-			model.vertexPositionsY = initialVertexPositionsY;
-			model.vertexPositionsZ = initialVertexPositionsZ;
-			const loaded = model.loadFrame(model, frame);
-			model.vertexPositionsX = loaded.vertices.map((v) => v[0]);
-			model.vertexPositionsY = loaded.vertices.map((v) => -v[1]);
-			model.vertexPositionsZ = loaded.vertices.map((v) => -v[2]);
+                const exporter = new GLTFExporter(model);
+                //frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+                //exporter.addAnimation(animation);
 
-			const exporter = new GLTFExporter(model);
-			//frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
-			//exporter.addAnimation(animation);
+                const gltf = exporter.export();
 
-			const gltf = exporter.export();
-
-			const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
-			fs.writeFileSync(path, gltf);
-			console.log(`Wrote file to ${path}`);
-		}
-	}
-}
+                const path = `./out/${npc.id}_${model.id}_${animation.id}_${frame.id}.gltf`;
+                fs.writeFileSync(path, gltf);
+                console.log(`Wrote file to ${path}`);
+            }
+        }
+    }
 };
 
 let cache = new RSCache("./cache");
 cache.onload.then(async () => {
-	console.log("Loaded");
-	for (const npc of npcsAndAnimations) {
-		await processNpc(npc);
-	}
-	cache.close();
-	return true;
+    console.log("Loaded");
+    for (const npc of npcsAndAnimations) {
+        await processNpc(npc);
+    }
+    cache.close();
+    return true;
 });

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -5,11 +5,13 @@ import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 const DUMP_FRAMES = false;
 
 const npcsAndAnimations = [
-    /*{
+    {
         npcId: 7706, // zuk
         animations: [
             7564, // idle
             7566, // fire
+            7565, // flinch
+            7562, // die
         ],
     },
     {
@@ -18,8 +20,11 @@ const npcsAndAnimations = [
             7602, // idle
             7603, // walk
             7605, // fire
+            7604, // melee attack
+            7606, // die
+            7607, // flinch
         ],
-    },*/
+    },
     {
         npcId: 7699, // mager
         animations: [
@@ -27,6 +32,8 @@ const npcsAndAnimations = [
             7608, // walk
             7610, // mage fire
             7611, // revive
+			7612, // melee attack
+			7613, // death
         ],
     },
     {
@@ -35,13 +42,17 @@ const npcsAndAnimations = [
             7573, // idle
             7572, // walk
             7574, // attack
+            7575, // flinch
+			7676, // die
         ],
-    },/*
+    },
     {
         npcId: 7692, // bat
         animations: [
             7577, // idle and walk
             7578, // attack
+            7579, // flinch
+            7580, // die
         ],
     },
     {
@@ -50,6 +61,10 @@ const npcsAndAnimations = [
             7586, // idle
 			7587, // walk
             7581, // attack (is it mage?)
+            7582, // attack melee
+            7583, // attack range
+            7585, // flinch
+            7584, // die
         ],
     },
     {
@@ -58,17 +73,22 @@ const npcsAndAnimations = [
             7595, // idle
 			7596, // walk
             7597, // attack
-			7600, // dig
+			7600, // dig down
 			7601, // dig up
+            7598, // flinch
+            7599, // die
         ],
-    },*/
-    /*{
+    },
+	{
         npcId: 7700, // jad
         animations: [
             7589, // idle
             7588, // walk
             7592, // attack mage
             7593, // attack range
+            7590, // attack melee
+            7591, // flinch
+            7594, // die
         ],
     },
 	{
@@ -76,6 +96,13 @@ const npcsAndAnimations = [
 		animations: [
 			7567, // idle
 			7569, // dying
+		]
+	},
+	/*{
+		npcId: 8636, // third age ranger. doesnt work, better luck next time
+		animations: [
+			808, // idle
+			819, // walking
 		]
 	}*/
 ];
@@ -158,6 +185,7 @@ let cache = new RSCache("./cache");
 cache.onload.then(async () => {
     console.log("Loaded");
     for (const npc of npcsAndAnimations) {
+		console.log('loading npc:', npc.npcId);
         await processNpc(npc);
     }
     cache.close();

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -5,13 +5,13 @@ import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 let cache = new RSCache("./cache");
 cache.onload.then(async () => {
 	console.log("Loaded");
-	//const npcId = 7706; // zuk
-	const npcId = 7698;
+	const npcId = 7706; // zuk
+	//const npcId = 7698;
 	let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
 
 	// zuk idle
-	//const animId = 7564;
-	const animId = 7605;
+	const animId = 7564;
+	//const animId = 7605;
 	for (let i = 0; i < npc.models.length; ++i) {
 		let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
 
@@ -33,7 +33,17 @@ cache.onload.then(async () => {
 		let initialVertexPositionsX = model.vertexPositionsX;
 		let initialVertexPositionsY = model.vertexPositionsY;
 		let initialVertexPositionsZ = model.vertexPositionsZ;
-		
+
+		const exporter = new GLTFExporter(model);
+		frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+		exporter.addAnimation(animation);
+
+		const gltf = exporter.export();
+
+		const path = `./out/${npc.id}_${model.id}_${animation.id}.gltf`;
+		fs.writeFileSync(path, gltf);
+		console.log(`Wrote single file to ${path}`);
+
 		let frameDefs = (await cache.getAllFiles(IndexType.FRAMES.id, shiftedId)).map(x => x.def);
 		for (const frame of frameDefs) {
 			model.vertexPositionsX = initialVertexPositionsX;

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -1,0 +1,45 @@
+import fs from "fs";
+
+import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
+
+let cache = new RSCache("./cache");
+cache.onload.then(async () => {
+	console.log("Loaded");
+	//const npcId = 7706; // zuk
+	const npcId = 7698;
+	let npc = await cache.getDef(IndexType.CONFIGS, ConfigType.NPC, npcId);
+
+	// zuk idle
+	//const animId = 7564;
+	const animId = 7605;
+	for (let i = 0; i < npc.models.length; ++i) {
+		let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
+
+		const animationDef = await cache.getFile(
+			IndexType.CONFIGS.id,
+			ConfigType.SEQUENCE.id,
+			animId
+		);
+		let animation = animationDef.def;
+
+		let selectedAnimation = await cache.getFile(
+			IndexType.CONFIGS.id,
+			ConfigType.SEQUENCE.id,
+			animId
+		);
+		let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
+		let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
+
+		const exporter = new GLTFExporter(model);
+		frames.forEach((frame) => exporter.addMorphTarget(frame.vertices));
+		exporter.addAnimation(animation);
+
+		const gltf = exporter.export();
+
+		const path = `./out/${npc.id}_${model.id}.gltf`;
+		fs.writeFileSync(path, gltf);
+		console.log(`Wrote file to ${path}`);
+	}
+	cache.close();
+	return true;
+});

--- a/scripts/dumpModel.js
+++ b/scripts/dumpModel.js
@@ -5,7 +5,7 @@ import { RSCache, IndexType, ConfigType, GLTFExporter } from "osrscachereader";
 const DUMP_FRAMES = false;
 
 const npcsAndAnimations = [
-    {
+    /*{
         npcId: 7706, // zuk
         animations: [
             7564, // idle
@@ -19,15 +19,65 @@ const npcsAndAnimations = [
             7603, // walk
             7605, // fire
         ],
-    },
+    },*/
     {
         npcId: 7699, // mager
         animations: [
-            7609, // idle,
+            7609, // idle
             7608, // walk
             7610, // mage fire
+            7611, // revive
         ],
     },
+    {
+        npcId: 7691, // nibbler
+        animations: [
+            7573, // idle
+            7572, // walk
+            7574, // attack
+        ],
+    },/*
+    {
+        npcId: 7692, // bat
+        animations: [
+            7577, // idle and walk
+            7578, // attack
+        ],
+    },
+    {
+        npcId: 7693, // blob
+        animations: [
+            7586, // idle
+			7587, // walk
+            7581, // attack (is it mage?)
+        ],
+    },
+    {
+        npcId: 7697, // meleer
+        animations: [
+            7595, // idle
+			7596, // walk
+            7597, // attack
+			7600, // dig
+			7601, // dig up
+        ],
+    },*/
+    /*{
+        npcId: 7700, // jad
+        animations: [
+            7589, // idle
+            7588, // walk
+            7592, // attack mage
+            7593, // attack range
+        ],
+    },
+	{
+		npcId: 7707, // ancestral glyph
+		animations: [
+			7567, // idle
+			7569, // dying
+		]
+	}*/
 ];
 
 const processNpc = async ({ npcId, animations }) => {
@@ -37,6 +87,16 @@ const processNpc = async ({ npcId, animations }) => {
         let model = await cache.getDef(IndexType.MODELS, npc.models[i]);
 
         const loadedFrames = [];
+		// note: only need to ask for frames for the first animation
+		let selectedAnimation = await cache.getFile(
+			IndexType.CONFIGS.id,
+			ConfigType.SEQUENCE.id,
+			animations[0]
+		);
+		let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
+		let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
+		loadedFrames.push(...frames);
+
         const loadedAnimations = [];
         for (const animId of animations) {
             const animationDef = await cache.getFile(
@@ -46,20 +106,11 @@ const processNpc = async ({ npcId, animations }) => {
             );
             let animation = animationDef.def;
             loadedAnimations.push(animation);
-
-            let selectedAnimation = await cache.getFile(
-                IndexType.CONFIGS.id,
-                ConfigType.SEQUENCE.id,
-                animId
-            );
-            let shiftedId = selectedAnimation.def.frameIDs[0] >> 16;
-            let frames = await model.loadSkeletonAnims(cache, model, shiftedId);
-            loadedFrames.push(...frames);
         }
 
         const exporter = new GLTFExporter(model);
         loadedFrames.forEach((frame) =>
-            exporter.addMorphTarget(frame.vertices)
+			exporter.addMorphTarget(frame.vertices)
         );
         exporter.addColors(model);
         loadedAnimations.forEach((animation) => {

--- a/src/cacheReader/RSCache.js
+++ b/src/cacheReader/RSCache.js
@@ -244,9 +244,13 @@ class RSCache {
 			}
 			this.indicies[i] = new Index(i);
 			for (let j = 0; j < dataview.byteLength; j += 6) {
-				let size = dataview.readUint24();
-				let segment = dataview.readUint24();
-				this.indicies[i].indexSegments.push({ size, segment });
+				try {
+					let size = dataview.readUint24();
+					let segment = dataview.readUint24();
+					this.indicies[i].indexSegments.push({ size, segment });
+				} catch (err) {
+					console.error(`error reading index ${i} pos ${j}`, err);
+				}
 			}
 
 		};

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -396,14 +396,20 @@ class GLTFFile {
             byteLength: uvBytes.length,
         });
 
+        let min = [1.0, 1.0];
+        let max = [0.0, 0.0];
+        for (let i = 0; i < uvs.length; i++) {
+            max = [Math.max(max[0], uvs[i][0]), Math.max(max[1], uvs[i][1])];
+            min = [Math.min(min[0], uvs[i][0]), Math.min(min[1], uvs[i][1])];
+        }
         this.accessors.push({
             bufferView: buffersAmount,
             byteOffset: 0,
             componentType: 5126,
             count: uvs.length,
             type: "VEC2",
-            max: [1.0, 1.0],
-            min: [0.0, 0.0]
+            max,
+            min,
         });
 
         this.meshes[0].primitives[0].attributes.TEXCOORD_0 = this.accessors.length - 1;

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -459,25 +459,11 @@ export default class GLTFExporter {
 		const colorToPaletteIndex = {};
 		const order = [];
 
-		let brightness = 1.7;
-		let newColours = [];
-		for (let i = 0; i < def.faceColors.length; i++) {
-			let color = HSLtoRGB(def.faceColors[i], BRIGHTNESS_MAX);
-			let r = ((color >> 16) & 0xff) / 255.0;
-			let g = ((color >> 8) & 0xff) / 255.0;
-			let b = (color & 0xff) / 255.0;
-			newColours.push([r, g, b]);
-		}
-
 		for (let i = 0; i < def.faceColors.length; ++i) {
 			if (faceColors[def.faceColors[i]]) {
 				continue;
 			}
 			let rscolor = def.faceColors[i];
-			//let hue = (rscolor >> 10) & 0x3f;
-			//let saturation = (rscolor >> 7) & 0x07;
-			//let brightness = (rscolor & 0x7f);
-			//let color = HSVtoRGB(hue / 63, saturation / 7, brightness / 127);
 			let color = HSLtoRGB(rscolor, BRIGHTNESS_MAX);
 			let r = ((color >> 16) & 0xff) / 255.0;
 			let g = ((color >> 8) & 0xff) / 255.0;

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -133,21 +133,21 @@ function adjustForBrightness(rgb, brightness) {
 class GLTFFile {
     //Basically just setting it up for 1 model
     scene = 0;
-    scenes = [
-        { nodes: [0] }
-    ];
+    scenes = [{ nodes: [0] }];
 
     nodes = [{ mesh: 0 }];
 
     meshes = [
         {
-            primitives: [{
-                attributes: {
-                    POSITION: 1
+            primitives: [
+                {
+                    attributes: {
+                        POSITION: 0,
+                    },
+                    //indices: 0,
                 },
-                indices: 0,
-            }]
-        }
+            ],
+        },
     ];
 
     textures = [];
@@ -162,14 +162,18 @@ class GLTFFile {
     accessors = [];
 
     asset = {
-        version: "2.0"
+        version: "2.0",
     };
 
     addIndicies(indicies) {
-        let indicesBytes = new Uint8Array(new Uint16Array(indicies.flat()).buffer)
+        let indicesBytes = new Uint8Array(
+            new Uint16Array(indicies.flat()).buffer
+        );
         let buffersAmount = this.buffers.length;
         this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(indicesBytes),
+            uri:
+                "data:application/octet-stream;base64," +
+                base64.bytesToBase64(indicesBytes),
             byteLength: indicesBytes.length,
         });
 
@@ -177,10 +181,12 @@ class GLTFFile {
             buffer: buffersAmount,
             byteOffset: 0,
             byteLength: indicesBytes.length,
-            target: 34963
+            target: 34963,
         });
 
-        let max = indicies.flat().reduce((max, current) => Math.max(max, current));
+        let max = indicies
+            .flat()
+            .reduce((max, current) => Math.max(max, current));
         this.accessors.push({
             bufferView: 0,
             byteOffset: 0,
@@ -188,7 +194,7 @@ class GLTFFile {
             count: indicesBytes.length / 2,
             type: "SCALAR",
             max: [max],
-            min: [0]
+            min: [0],
         });
     }
 
@@ -196,16 +202,27 @@ class GLTFFile {
         let max = [0, 0, 0];
         let min = [0, 0, 0];
         for (let i = 0; i < verticies.length; i++) {
-            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
-            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
+            max = [
+                Math.max(max[0], verticies[i][0]),
+                Math.max(max[1], verticies[i][1]),
+                Math.max(max[2], verticies[i][2]),
+            ];
+            min = [
+                Math.min(min[0], verticies[i][0]),
+                Math.min(min[1], verticies[i][1]),
+                Math.min(min[2], verticies[i][2]),
+            ];
         }
 
-        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
-
+        let verticiesBytes = new Uint8Array(
+            new Float32Array(verticies.flat()).buffer
+        );
 
         let buffersAmount = this.buffers.length;
         this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
+            uri:
+                "data:application/octet-stream;base64," +
+                base64.bytesToBase64(verticiesBytes),
             byteLength: verticiesBytes.length,
         });
 
@@ -222,20 +239,29 @@ class GLTFFile {
             count: verticies.length,
             type: "VEC3",
             max,
-            min
+            min,
         });
     }
 
     addMorphTarget(verticies) {
-        //verticies.forEach(x => x[2] *= -1);
         let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
         let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
         for (let i = 0; i < verticies.length; i++) {
-            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
-            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
+            max = [
+                Math.max(max[0], verticies[i][0]),
+                Math.max(max[1], verticies[i][1]),
+                Math.max(max[2], verticies[i][2]),
+            ];
+            min = [
+                Math.min(min[0], verticies[i][0]),
+                Math.min(min[1], verticies[i][1]),
+                Math.min(min[2], verticies[i][2]),
+            ];
         }
 
-        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
+        let verticiesBytes = new Uint8Array(
+            new Float32Array(verticies.flat()).buffer
+        );
 
         if (!("targets" in this.meshes[0].primitives[0])) {
             this.meshes[0].primitives[0].targets = [];
@@ -249,17 +275,19 @@ class GLTFFile {
         } else {
             this.meshes[0].weights.push(0);
         }
-        this.meshes[0].primitives[0].targets.push({ "POSITION": buffersAmount });
+        this.meshes[0].primitives[0].targets.push({ POSITION: buffersAmount });
 
         this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
+            uri:
+                "data:application/octet-stream;base64," +
+                base64.bytesToBase64(verticiesBytes),
             byteLength: verticiesBytes.length,
         });
         this.bufferViews.push({
             buffer: buffersAmount,
             byteOffset: 0,
             byteLength: verticiesBytes.length,
-            target: 34962
+            target: 34962,
         });
 
         this.accessors.push({
@@ -269,29 +297,35 @@ class GLTFFile {
             count: verticies.length,
             type: "VEC3",
             max,
-            min
+            min,
         });
 
         //animations needs to be adjusted if more morph targets are added after anims
     }
 
     addAnimation(targets, lengths, morphTargetsAmount) {
-        targets = targets.map(x => {
-            let oneHot = new Array(morphTargetsAmount).fill(0)
+        targets = targets.map((x) => {
+            let oneHot = new Array(morphTargetsAmount).fill(0);
             oneHot[x] = 1;
-            return oneHot
+            return oneHot;
         }); //one hot encoding
 
-        let targetBytes = new Uint8Array(new Float32Array(targets.flat()).buffer);
+        let targetBytes = new Uint8Array(
+            new Float32Array(targets.flat()).buffer
+        );
         let lengthsBytes = new Uint8Array(new Float32Array(lengths).buffer);
 
-        let mergedBytes = new Uint8Array(lengthsBytes.length + targetBytes.length);
+        let mergedBytes = new Uint8Array(
+            lengthsBytes.length + targetBytes.length
+        );
         mergedBytes.set(lengthsBytes);
         mergedBytes.set(targetBytes, lengthsBytes.length);
 
         let buffersAmount = this.buffers.length;
         this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(mergedBytes),
+            uri:
+                "data:application/octet-stream;base64," +
+                base64.bytesToBase64(mergedBytes),
             byteLength: mergedBytes.length,
         });
 
@@ -322,7 +356,7 @@ class GLTFFile {
             count: targets.length,
             type: "SCALAR",
             max: [max],
-            min: [min]
+            min: [min],
         });
 
         this.accessors.push({
@@ -332,23 +366,27 @@ class GLTFFile {
             count: morphTargetsAmount * targets.length,
             type: "SCALAR",
             max: [1.0],
-            min: [0.0]
+            min: [0.0],
         });
 
         let animationsLength = this.animations.length;
         this.animations.push({
-            samplers: [{
-                input: accessorsLength,
-                interpolation: "STEP",
-                output: accessorsLength + 1
-            }],
-            channels: [{
-                sampler: 0,
-                target: {
-                    node: 0,
-                    path: "weights"
-                }
-            }]
+            samplers: [
+                {
+                    input: accessorsLength,
+                    interpolation: "STEP",
+                    output: accessorsLength + 1,
+                },
+            ],
+            channels: [
+                {
+                    sampler: 0,
+                    target: {
+                        node: 0,
+                        path: "weights",
+                    },
+                },
+            ],
         });
     }
 
@@ -358,41 +396,43 @@ class GLTFFile {
         const texturesAmount = this.textures.length;
         this.textures.push({
             source: texturesAmount,
-            sampler: texturesAmount
+            sampler: texturesAmount,
         });
 
         this.images.push({
-            uri: colorPalettePng
-		});
+            uri: colorPalettePng,
+        });
 
         this.samplers.push({
             magFilter: 9728,
             minFilter: 9987,
             wrapS: 33648,
-            wrapT: 33648
+            wrapT: 33648,
         });
 
         this.materials.push({
-            pbrMetallicRoughness : {
-			  baseColorFactor: [ 1.0, 1.0, 1.0, 1.0],
-              baseColorTexture : {
-                index : 0
-              },
-              metallicFactor : 0.0,
-              roughnessFactor : 1.0
-            }
+            pbrMetallicRoughness: {
+                baseColorFactor: [1.0, 1.0, 1.0, 1.0],
+                baseColorTexture: {
+                    index: 0,
+                },
+                metallicFactor: 0.0,
+                roughnessFactor: 1.0,
+            },
         });
-        
+
         let buffersAmount = this.buffers.length;
         this.buffers.push({
-            uri: "data:application/gltf-buffer;base64," + base64.bytesToBase64(uvBytes),
+            uri:
+                "data:application/gltf-buffer;base64," +
+                base64.bytesToBase64(uvBytes),
             byteLength: uvBytes.length,
         });
 
         this.bufferViews.push({
             buffer: buffersAmount,
             byteOffset: 0,
-            target : 34962,
+            target: 34962,
             byteLength: uvBytes.length,
         });
 
@@ -412,109 +452,124 @@ class GLTFFile {
             min,
         });
 
-        this.meshes[0].primitives[0].attributes.TEXCOORD_0 = this.accessors.length - 1;
+        this.meshes[0].primitives[0].attributes.TEXCOORD_0 =
+            this.accessors.length - 1;
         this.meshes[0].primitives[0].material = 0;
     }
 }
 
 export default class GLTFExporter {
-
     verticies = [];
     morphTargetsAmount = 0;
+
+    remappedVertices = {};
 
     constructor(def) {
         this.file = new GLTFFile();
 
         this.verticies = [];
-        for (let i = 0; i < def.vertexPositionsX.length; i++) {
-            this.verticies.push([def.vertexPositionsX[i], -def.vertexPositionsY[i], -def.vertexPositionsZ[i]]);
-        }
 
-        let indicies = [];
+        // n.b. we reorder the vertices by faces. this duplicates all of the vertices but allows us to
+        // apply per-face textures/colours and removes the need for indices.
         for (let i = 0; i < def.faceVertexIndices1.length; i++) {
-            indicies.push([def.faceVertexIndices1[i], def.faceVertexIndices2[i], def.faceVertexIndices3[i]]);
+            const v1 = def.faceVertexIndices1[i];
+            const v2 = def.faceVertexIndices2[i];
+            const v3 = def.faceVertexIndices3[i];
+            const faceVertices = [v1, v2, v3];
+            faceVertices.forEach((idx, pos) => {
+                this.verticies.push([
+                    def.vertexPositionsX[idx],
+                    -def.vertexPositionsY[idx],
+                    -def.vertexPositionsZ[idx],
+                ]);
+                if (!(idx in this.remappedVertices)) {
+                    this.remappedVertices[idx] = [];
+                }
+                // maintain a multimap of original vertex ID to where they are now in `this.verticies`.
+                this.remappedVertices[idx].push(i * 3 + pos);
+            });
         }
-
-        this.file.addIndicies(indicies);
         this.file.addVerticies(this.verticies);
     }
 
     addMorphTarget(morphVertices) {
+        let newMorphVertices = [];
         for (let i = 0; i < morphVertices.length; i++) {
-            morphVertices[i][0] -= this.verticies[i][0];
-            morphVertices[i][1] -= this.verticies[i][1];
-            morphVertices[i][2] -= this.verticies[i][2];
+            const realVertices = this.remappedVertices[i];
+            for (const realVertex of realVertices) {
+                newMorphVertices[realVertex] = [];
+                newMorphVertices[realVertex][0] =
+                    morphVertices[i][0] - this.verticies[realVertex][0];
+                newMorphVertices[realVertex][1] =
+                    morphVertices[i][1] - this.verticies[realVertex][1];
+                newMorphVertices[realVertex][2] =
+                    morphVertices[i][2] - this.verticies[realVertex][2];
+            }
         }
 
         this.morphTargetsAmount++;
-        this.file.addMorphTarget(morphVertices);
+        this.file.addMorphTarget(newMorphVertices);
     }
 
     addAnimation(def) {
-        let frames = def.frameIDs.map(x => x & 65535);
+        let frames = def.frameIDs.map((x) => x & 65535);
         let lengths = Object.assign([], def.frameLengths);
         for (let i = 1; i < lengths.length; i++) {
             lengths[i] += lengths[i - 1];
         }
-        lengths = lengths.map(x => x / 50);
+        lengths = lengths.map((x) => x / 50);
         this.file.addAnimation(frames, lengths, this.morphTargetsAmount);
     }
 
     addColors(def) {
-		const faceColors = {};
-		const colorToPaletteIndex = {};
-		const order = [];
+        const faceColors = {};
+        const colorToPaletteIndex = {};
+        const order = [];
 
-		for (let i = 0; i < def.faceColors.length; ++i) {
-			if (faceColors[def.faceColors[i]]) {
-				continue;
-			}
-			let rscolor = def.faceColors[i];
-			let color = HSLtoRGB(rscolor, BRIGHTNESS_MAX);
-			let r = ((color >> 16) & 0xff) / 255.0;
-			let g = ((color >> 8) & 0xff) / 255.0;
-			let b = (color & 0xff) / 255.0;
-			console.log(`rscolor ${rscolor} rgb ${r} ${g} ${b}`)
-			faceColors[rscolor] = color;
-			colorToPaletteIndex[rscolor] = Object.keys(faceColors).length - 1;
-			order.push(rscolor);
-		}
-		const numUniqueColors = Object.keys(faceColors).length;
-		// create a texture for the face colors
-		const pSize = 16;
-		const canvas = createCanvas(numUniqueColors * pSize, pSize, "png");
-		const ctx = canvas.getContext('2d');
-		let xx = 0;
-		for (const rscolor of order) {
-			const rgb = faceColors[rscolor];
-			let r = ((rgb >> 16) & 0xff);
-			let g = ((rgb >> 8) & 0xff);
-			let b = (rgb & 0xff);
-			ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
-			ctx.fillRect(xx, 0, pSize, pSize);
-			xx += pSize;
-		}
-		const colorPalettePng = canvas.toDataURL();
+        for (let i = 0; i < def.faceColors.length; ++i) {
+            if (faceColors[def.faceColors[i]]) {
+                continue;
+            }
+            let rscolor = def.faceColors[i];
+            let color = HSLtoRGB(rscolor, BRIGHTNESS_MAX);
+            let r = ((color >> 16) & 0xff) / 255.0;
+            let g = ((color >> 8) & 0xff) / 255.0;
+            let b = (color & 0xff) / 255.0;
+            console.log(`rscolor ${rscolor} rgb ${r} ${g} ${b}`);
+            faceColors[rscolor] = color;
+            colorToPaletteIndex[rscolor] = Object.keys(faceColors).length - 1;
+            order.push(rscolor);
+        }
+        const numUniqueColors = Object.keys(faceColors).length;
+        // create a texture for the face colors
+        const pSize = 16;
+        const canvas = createCanvas(numUniqueColors * pSize, pSize, "png");
+        const ctx = canvas.getContext("2d");
+        let xx = 0;
+        for (const rscolor of order) {
+            const rgb = faceColors[rscolor];
+            let r = (rgb >> 16) & 0xff;
+            let g = (rgb >> 8) & 0xff;
+            let b = rgb & 0xff;
+            ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+            ctx.fillRect(xx, 0, pSize, pSize);
+            xx += pSize;
+        }
+        const colorPalettePng = canvas.toDataURL();
 
-		// TODO: this is not right - we need to duplicate vertex positions
-        let uvs = new Array(def.vertexPositionsX.length);
-		const half = (1 / numUniqueColors) / 2;
-		const full = 1 / numUniqueColors;
-		for (let i = 0; i < def.faceColors.length; ++i) {
-			const faceColor = def.faceColors[i];
-			const v1 = def.faceVertexIndices1[i];
-			const v2 = def.faceVertexIndices2[i];
-			const v3 = def.faceVertexIndices3[i];
-			const paletteIndex = colorToPaletteIndex[faceColor];
-			uvs[v1] = [paletteIndex / numUniqueColors + half, 0.33];
-			uvs[v2] = [paletteIndex / numUniqueColors + half, 0.5];
-			uvs[v3] = [paletteIndex / numUniqueColors + half, 0.66];
-		}
+        let uvs = new Array(def.faceColors.length * 3);
+        const half = 1 / numUniqueColors / 2;
+        for (let i = 0; i < def.faceColors.length; ++i) {
+            const faceColor = def.faceColors[i];
+            const paletteIndex = colorToPaletteIndex[faceColor];
+            uvs[i * 3] = [paletteIndex / numUniqueColors + half, 0.33];
+            uvs[i * 3 + 1] = [paletteIndex / numUniqueColors + half, 0.5];
+            uvs[i * 3 + 2] = [paletteIndex / numUniqueColors + half, 0.66];
+        }
         this.file.addColors(uvs, colorPalettePng, colorToPaletteIndex);
     }
 
     export() {
         return JSON.stringify(this.file);
     }
-
 }

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -2,337 +2,375 @@ import * as base64 from "../helpers/base64.js"
 import { isBrowser } from "browser-or-node";
 
 class GLTFFile {
-    //Basically just setting it up for 1 model
-    scene = 0;
-    scenes = [
-        { nodes: [0] }
-    ];
+	//Basically just setting it up for 1 model
+	scene = 0;
+	scenes = [{ nodes: [0] }];
 
-    nodes = [{ mesh: 0 }];
+	nodes = [{ mesh: 0 }];
 
-    meshes = [
-        {
-            primitives: [{
-                attributes: {
-                    POSITION: 1
-                },
-                indices: 0,
-            }]
-        }
-    ];
+	meshes = [
+		{
+			primitives: [
+				{
+					attributes: {
+						POSITION: 1,
+					},
+					indices: 0,
+				},
+			],
+		},
+	];
 
-    textures = [];
-    images = [];
-    samplers = [];
-    materials = [];
-    animations = [];
+	textures = [];
+	images = [];
+	samplers = [];
+	materials = [];
+	animations = [];
 
-    buffers = [];
-    bufferViews = [];
+	buffers = [];
+	bufferViews = [];
 
-    accessors = [];
+	accessors = [];
 
-    asset = {
-        version: "2.0"
-    };
+	asset = {
+		version: "2.0",
+	};
 
-    addIndicies(indicies) {
-        let indicesBytes = new Uint8Array(new Uint16Array(indicies.flat()).buffer)
-        let buffersAmount = this.buffers.length;
-        this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(indicesBytes),
-            byteLength: indicesBytes.length,
-        });
+	addIndicies(indicies) {
+		let indicesBytes = new Uint8Array(new Uint16Array(indicies.flat()).buffer);
+		let buffersAmount = this.buffers.length;
+		this.buffers.push({
+			uri:
+				"data:application/octet-stream;base64," +
+				base64.bytesToBase64(indicesBytes),
+			byteLength: indicesBytes.length,
+		});
 
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: 0,
-            byteLength: indicesBytes.length,
-            target: 34963
-        });
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: 0,
+			byteLength: indicesBytes.length,
+			target: 34963,
+		});
 
-        let max = indicies.flat().reduce((max, current) => Math.max(max, current));
-        this.accessors.push({
-            bufferView: 0,
-            byteOffset: 0,
-            componentType: 5123,
-            count: indicesBytes.length / 2,
-            type: "SCALAR",
-            max: [max],
-            min: [0]
-        });
-    }
+		let max = indicies.flat().reduce((max, current) => Math.max(max, current));
+		this.accessors.push({
+			bufferView: 0,
+			byteOffset: 0,
+			componentType: 5123,
+			count: indicesBytes.length / 2,
+			type: "SCALAR",
+			max: [max],
+			min: [0],
+		});
+	}
 
-    addVerticies(verticies) {
-        let max = [0, 0, 0];
-        let min = [0, 0, 0];
-        for (let i = 0; i < verticies.length; i++) {
-            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
-            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
-        }
+	addVerticies(verticies) {
+		let max = [0, 0, 0];
+		let min = [0, 0, 0];
+		for (let i = 0; i < verticies.length; i++) {
+			max = [
+				Math.max(max[0], verticies[i][0]),
+				Math.max(max[1], verticies[i][1]),
+				Math.max(max[2], verticies[i][2]),
+			];
+			min = [
+				Math.min(min[0], verticies[i][0]),
+				Math.min(min[1], verticies[i][1]),
+				Math.min(min[2], verticies[i][2]),
+			];
+		}
 
-        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
+		let verticiesBytes = new Uint8Array(
+			new Float32Array(verticies.flat()).buffer
+		);
 
+		let buffersAmount = this.buffers.length;
+		this.buffers.push({
+			uri:
+				"data:application/octet-stream;base64," +
+				base64.bytesToBase64(verticiesBytes),
+			byteLength: verticiesBytes.length,
+		});
 
-        let buffersAmount = this.buffers.length;
-        this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
-            byteLength: verticiesBytes.length,
-        });
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: 0,
+			byteLength: verticiesBytes.length,
+		});
 
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: 0,
-            byteLength: verticiesBytes.length,
-        });
+		this.accessors.push({
+			bufferView: buffersAmount,
+			byteOffset: 0,
+			componentType: 5126,
+			count: verticies.length,
+			type: "VEC3",
+			max,
+			min,
+		});
+	}
 
-        this.accessors.push({
-            bufferView: buffersAmount,
-            byteOffset: 0,
-            componentType: 5126,
-            count: verticies.length,
-            type: "VEC3",
-            max,
-            min
-        });
-    }
+	addMorphTarget(verticies) {
+		let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
+		let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
+		for (let i = 0; i < verticies.length; i++) {
+			max = [
+				Math.max(max[0], verticies[i][0]),
+				Math.max(max[1], verticies[i][1]),
+				Math.max(max[2], verticies[i][2]),
+			];
+			min = [
+				Math.min(min[0], verticies[i][0]),
+				Math.min(min[1], verticies[i][1]),
+				Math.min(min[2], verticies[i][2]),
+			];
+		}
 
-    addMorphTarget(verticies) {
-        //verticies.forEach(x => x[2] *= -1);
-        let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
-        let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
-        for (let i = 0; i < verticies.length; i++) {
-            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
-            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
-        }
+		let verticiesBytes = new Uint8Array(
+			new Float32Array(verticies.flat()).buffer
+		);
 
-        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
+		if (!("targets" in this.meshes[0].primitives[0])) {
+			this.meshes[0].primitives[0].targets = [];
+			this.meshes[0].weights = [];
+		}
 
-        if (!("targets" in this.meshes[0].primitives[0])) {
-            this.meshes[0].primitives[0].targets = [];
-            this.meshes[0].weights = [];
-        }
+		let buffersAmount = this.buffers.length;
 
-        let buffersAmount = this.buffers.length;
+		if (this.meshes[0].weights.length == 0) {
+			this.meshes[0].weights.push(1);
+		} else {
+			this.meshes[0].weights.push(0);
+		}
+		this.meshes[0].primitives[0].targets.push({ POSITION: buffersAmount });
 
-        if (this.meshes[0].weights.length == 0) {
-            this.meshes[0].weights.push(1);
-        } else {
-            this.meshes[0].weights.push(0);
-        }
-        this.meshes[0].primitives[0].targets.push({ "POSITION": buffersAmount });
+		this.buffers.push({
+			uri:
+				"data:application/octet-stream;base64," +
+				base64.bytesToBase64(verticiesBytes),
+			byteLength: verticiesBytes.length,
+		});
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: 0,
+			byteLength: verticiesBytes.length,
+			target: 34962,
+		});
 
-        this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
-            byteLength: verticiesBytes.length,
-        });
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: 0,
-            byteLength: verticiesBytes.length,
-            target: 34962
-        });
+		this.accessors.push({
+			bufferView: buffersAmount,
+			byteOffset: 0,
+			componentType: 5126,
+			count: verticies.length,
+			type: "VEC3",
+			max,
+			min,
+		});
 
-        this.accessors.push({
-            bufferView: buffersAmount,
-            byteOffset: 0,
-            componentType: 5126,
-            count: verticies.length,
-            type: "VEC3",
-            max,
-            min
-        });
+		//animations needs to be adjusted if more morph targets are added after anims
+	}
 
-        //animations needs to be adjusted if more morph targets are added after anims
-    }
+	addAnimation(targets, lengths, morphTargetsAmount) {
+		targets = targets.map((x) => {
+			let oneHot = new Array(morphTargetsAmount).fill(0);
+			oneHot[x] = 1;
+			return oneHot;
+		}); //one hot encoding
 
-    addAnimation(targets, lengths, morphTargetsAmount) {
-        targets = targets.map(x => {
-            let oneHot = new Array(morphTargetsAmount).fill(0)
-            oneHot[x] = 1;
-            return oneHot
-        }); //one hot encoding
+		let targetBytes = new Uint8Array(new Float32Array(targets.flat()).buffer);
+		let lengthsBytes = new Uint8Array(new Float32Array(lengths).buffer);
 
-        let targetBytes = new Uint8Array(new Float32Array(targets.flat()).buffer);
-        let lengthsBytes = new Uint8Array(new Float32Array(lengths).buffer);
+		let mergedBytes = new Uint8Array(lengthsBytes.length + targetBytes.length);
+		mergedBytes.set(lengthsBytes);
+		mergedBytes.set(targetBytes, lengthsBytes.length);
 
-        let mergedBytes = new Uint8Array(lengthsBytes.length + targetBytes.length);
-        mergedBytes.set(lengthsBytes);
-        mergedBytes.set(targetBytes, lengthsBytes.length);
+		let buffersAmount = this.buffers.length;
+		this.buffers.push({
+			uri:
+				"data:application/octet-stream;base64," +
+				base64.bytesToBase64(mergedBytes),
+			byteLength: mergedBytes.length,
+		});
 
-        let buffersAmount = this.buffers.length;
-        this.buffers.push({
-            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(mergedBytes),
-            byteLength: mergedBytes.length,
-        });
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: 0,
+			byteLength: lengthsBytes.length,
+		});
 
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: 0,
-            byteLength: lengthsBytes.length,
-        });
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: lengthsBytes.length,
+			byteLength: targetBytes.length,
+		});
 
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: lengthsBytes.length,
-            byteLength: targetBytes.length,
-        });
+		let max = lengths[0];
+		let min = lengths[0];
+		for (let i = 0; i < lengths.length; i++) {
+			max = Math.max(max, lengths[i]);
+			min = Math.min(min, lengths[i]);
+		}
 
-        let max = lengths[0];
-        let min = lengths[0];
-        for (let i = 0; i < lengths.length; i++) {
-            max = Math.max(max, lengths[i]);
-            min = Math.min(min, lengths[i]);
-        }
+		let accessorsLength = this.accessors.length;
+		this.accessors.push({
+			bufferView: this.bufferViews.length - 2,
+			byteOffset: 0,
+			componentType: 5126,
+			count: targets.length,
+			type: "SCALAR",
+			max: [max],
+			min: [min],
+		});
 
-        let accessorsLength = this.accessors.length;
-        this.accessors.push({
-            bufferView: this.bufferViews.length - 2,
-            byteOffset: 0,
-            componentType: 5126,
-            count: targets.length,
-            type: "SCALAR",
-            max: [max],
-            min: [min]
-        });
+		this.accessors.push({
+			bufferView: this.bufferViews.length - 1,
+			byteOffset: 0,
+			componentType: 5126,
+			count: morphTargetsAmount * targets.length,
+			type: "SCALAR",
+			max: [1.0],
+			min: [0.0],
+		});
 
-        this.accessors.push({
-            bufferView: this.bufferViews.length - 1,
-            byteOffset: 0,
-            componentType: 5126,
-            count: morphTargetsAmount * targets.length,
-            type: "SCALAR",
-            max: [1.0],
-            min: [0.0]
-        });
+		let animationsLength = this.animations.length;
+		this.animations.push({
+			samplers: [
+				{
+					input: accessorsLength,
+					interpolation: "STEP",
+					output: accessorsLength + 1,
+				},
+			],
+			channels: [
+				{
+					sampler: 0,
+					target: {
+						node: 0,
+						path: "weights",
+					},
+				},
+			],
+		});
+	}
 
-        let animationsLength = this.animations.length;
-        this.animations.push({
-            samplers: [{
-                input: accessorsLength,
-                interpolation: "STEP",
-                output: accessorsLength + 1
-            }],
-            channels: [{
-                sampler: 0,
-                target: {
-                    node: 0,
-                    path: "weights"
-                }
-            }]
-        });
-    }
+	addColors(uvs) {
+		let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
 
-    addColors(uvs) {
-        let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
+		const texturesAmount = this.textures.length;
+		this.textures.push({
+			source: texturesAmount,
+			sampler: texturesAmount,
+		});
 
-        const texturesAmount = this.textures.length;
-        this.textures.push({
-            source: texturesAmount,
-            sampler: texturesAmount
-        });
+		this.images.push({
+			uri: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAwaSURBVHic7dxfSJT5Hsfxj39a49jQlnA2z5gKa+FVS8nqLKxWs4V4ERgkWLJNu9DeBNEu23UE3QQbe9GSdeFFMNFlIBuLjTprm6E0MghLSDtauBHnXMT258xRGxfPRenmNuM4jz6jzvf9gt+Fzzi/mQf8vnlGx8mTNJMnicVi2VuFyhMAowgAYBgBAAwjAIBhBAAwLGkAXk3NZP+ZuMBXRN2wNHU5MguJFLOQ21cAuXxuQCZSzAIBACwgAIBhBAAwzI0ATE5O6ubNmxodHVVpaamam5vl8Xicb/g3ExMTc/t7vV41Nzdrw4YNi9+AACCLpqenFYlElEgkVF9fv6x7uzULjgMwNjamxsZGxWKxuWNer1fhcFjbtm1ztulbYrGYGhsbNTY2Nnds69atCofD+vDDDxe3CQGAy549e6ZgMKhQKKS+vj49f/5cJ0+eXNYAuDkLjgMQCAQUi8W0fft2NTU16fbt24pGozp8+LAGBgZUWFjobOM3Pv/8c42Njam6ulqNjY36+eefNTw8rLa2NvX396ugoCD9JgQALmttbVVXV5erj+HmLDgKQH9/v+7cuaOysjJFIhF5PB4lEgnt2rVLQ0NDunHjhlpaWjLf+I2+vj4NDAyooqJCkUhExcXFSiQS+uijjzQ4OKjOzk4dPHgw/UYEAC47cuSIvF6v6uvrNTIyovPnzy/r/m7PQn7S/xFM4/r165KkU6dOzb3mX7dunU6fPi1JunbtWvpNFrH/119/reLi4rn9v/3228z2X+n/tWSt/ZXG0aNH1dHRoWPHjqm0tDT9HTLk9iw4ugIYGRmRJO3cuXPe8ZqaGknS/fv3M9/Ujf0dnBuwmrg9C44C8PTpU0nSpk2b5h0vKSmR9PoXI0uxbPsTAKxxbs8C7wMALFjOAKxfv16SFI/H5x2f/Xr2tYpTy7Y/AcAa5/YsOPolYHl5uSTpwYMH847Pfr3U9wEs2/4r/Qsk1tpfK8ztWXAUgKamJknS5cuXNTPz179LXrlyRZLk9/sXvH84HFZ3d7eGh4cX3L+9vX3e8cXuP2elf3hYa3+5bKVnIU//fPdTgRP/Wfh/oOPxuKqrq/X48WMFAgEdOnRIoVBIFy9elMfj0fj4uDZu3Jj0vqOjo6qqqpIkBYNBtbW1vfM9L1++VHV1tZ48eaIvv/xSBw8eVFdXl3744Qe9//77Gh8fX9Rbjn0f5K34zw9rbS9fmlmIRqPq7OzUxMSEIpGIenp6VFNTo3379qmoqEh79+7Vnj17kt43m7OQSDkLHyQJwL/TfwhCKBTSgQMHNDU1NXesoKBAV69eTXoisy5duqQTJ05ox44dikajys/PT/p9P/30k5qbm/Xq1at5+weDQbW2tqZ9fpLk20IAWEtbvjSz4Pf7FQ6HU95eWVmphw8fJr0tm7OQSDELjv8KsH//ft29e1ft7e169OiRysvLdfz4cfl8vgXvN/u2yXPnzqU8Yen1pU9/f7/a29s1Pj6uiooKffXVV6qtrV38k3R4bsBiXbhwQbdu3Up5e11dXcrbVsMs5Kk0yRXAE3c+BmlqakolJSWqra1Vb2+vK4/xNt+/uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKeyJC8Bfs+NT0L1beUlAGtpy5cjs5BIMQu8FRiwIMUsEADAgkwC8F5ljlw6EwAs0WCOz0JuXwEAWBABAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAxLGoBXW2ey/0xc4PudumFp6nJkFhIpZiG3rwBy+dyATKSYBQIAWEAAAMMIAGCYGwGYnJzUzZs3NTo6qtLSUjU3N8vj8TjfMInp6Wndu3dPf/75pz799NPM7kwAkEXT09OKRCJKJBKqr693Zf/lngXHARgbG1NjY6NisdjcMa/Xq3A4rG3btjnb9I0//vhDwWBQoVBIfX19evHihb755hsCgFXn2bNn835Wnz9/rpMnTy5bANyeBccBCAQCisVi2r59u5qamnT79m1Fo1EdPnxYAwMDKiwsdLaxpJaWFvX09Di+/xwCAJe1traqq6vLtf3dngVHAejv79edO3dUVlamSCQij8ejRCKhXbt2aWhoSDdu3FBLS4vj59rW1qaKigo1NDTo119/1XfffedsIwIAlx05ckRer1f19fUaGRnR+fPnl3V/t2chX3lvbnx7pXH9+nVJ0qlTp+Ze869bt06nT5+WJF27ds3Zk3zjiy++UEdHhwKBgLZs2eJ8o2TnxmJlstI4evSoOjo6dOzYMZWWlqa/Q4bcngVHVwAjIyOSpJ07d847XlNTI0m6f/++8ye6nBycG5CTUsyCowA8ffpUkrRp06Z5x0tKSiS9/sXIqkAAgNeWMwBrRi6fG5CJ5QzA+vXrJUnxeHze8dmvi4uLM9/UDQQAeC3FLDj6JWB5ebkk6cGDB/OOz3691PcBLJuV/gUSa+2vXJHi/BwFoKmpSZJ0+fJlzcz89e+SV65ckST5/f4F7x8Oh9Xd3a3h4eGMzyMjK/3Dw1r7y2UrPQt5eqGZvx9PeBb+H+h4PK7q6mo9fvxYgUBAhw4dUigU0sWLF+XxeDQ+Pq6NGzcmve/o6KiqqqokScFgUG1tbe98z9DQkH788UdNTEzo3r176u3t1ccffyy/36+ioiJ99tlnamhoSHvOvpd5K/7zw1rby5dmFqLRqDo7OzUxMaFIJKKenh7V1NRo3759Kioq0t69e7Vnz56k983mLCRSzsLLJAHYkP5DEEKhkA4cOKCpqam5YwUFBbp69WrSE5l16dIlnThxQjt27FA0GlV+fv4739PQ0KBffvkl5R5VVVX67bff0j5H338JAGtpy5dmFvx+v8LhcMrbKysr9fDhw6S3ZXMWEilmwfFfAfbv36+7d++qvb1djx49Unl5uY4fPy6fz7fg/WbfNnnu3LmkJyxJ33//vbq7u1Pu8cknnyzuSTo8N2CxLly4oFu3bqW8va6uLuVtq2EW8hRPcgXwD3c+BmlqakolJSWqra1Vb2+vK4/xNt//uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKfJJC8BinLjk1B9U7wEYC1t+XJkFhIpZoG3AgMWpJgFAgBYkEkA3pvOkUtnAoAlGszxWcjtKwAACyIAgGEEADCMAACG/R+qH8xoau6KiAAAAABJRU5ErkJggg==`,
+		});
 
-        this.images.push({
-            uri: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAwaSURBVHic7dxfSJT5Hsfxj39a49jQlnA2z5gKa+FVS8nqLKxWs4V4ERgkWLJNu9DeBNEu23UE3QQbe9GSdeFFMNFlIBuLjTprm6E0MghLSDtauBHnXMT258xRGxfPRenmNuM4jz6jzvf9gt+Fzzi/mQf8vnlGx8mTNJMnicVi2VuFyhMAowgAYBgBAAwjAIBhBAAwLGkAXk3NZP+ZuMBXRN2wNHU5MguJFLOQ21cAuXxuQCZSzAIBACwgAIBhBAAwzI0ATE5O6ubNmxodHVVpaamam5vl8Xicb/g3ExMTc/t7vV41Nzdrw4YNi9+AACCLpqenFYlElEgkVF9fv6x7uzULjgMwNjamxsZGxWKxuWNer1fhcFjbtm1ztulbYrGYGhsbNTY2Nnds69atCofD+vDDDxe3CQGAy549e6ZgMKhQKKS+vj49f/5cJ0+eXNYAuDkLjgMQCAQUi8W0fft2NTU16fbt24pGozp8+LAGBgZUWFjobOM3Pv/8c42Njam6ulqNjY36+eefNTw8rLa2NvX396ugoCD9JgQALmttbVVXV5erj+HmLDgKQH9/v+7cuaOysjJFIhF5PB4lEgnt2rVLQ0NDunHjhlpaWjLf+I2+vj4NDAyooqJCkUhExcXFSiQS+uijjzQ4OKjOzk4dPHgw/UYEAC47cuSIvF6v6uvrNTIyovPnzy/r/m7PQn7S/xFM4/r165KkU6dOzb3mX7dunU6fPi1JunbtWvpNFrH/119/reLi4rn9v/3228z2X+n/tWSt/ZXG0aNH1dHRoWPHjqm0tDT9HTLk9iw4ugIYGRmRJO3cuXPe8ZqaGknS/fv3M9/Ujf0dnBuwmrg9C44C8PTpU0nSpk2b5h0vKSmR9PoXI0uxbPsTAKxxbs8C7wMALFjOAKxfv16SFI/H5x2f/Xr2tYpTy7Y/AcAa5/YsOPolYHl5uSTpwYMH847Pfr3U9wEs2/4r/Qsk1tpfK8ztWXAUgKamJknS5cuXNTPz179LXrlyRZLk9/sXvH84HFZ3d7eGh4cX3L+9vX3e8cXuP2elf3hYa3+5bKVnIU//fPdTgRP/Wfh/oOPxuKqrq/X48WMFAgEdOnRIoVBIFy9elMfj0fj4uDZu3Jj0vqOjo6qqqpIkBYNBtbW1vfM9L1++VHV1tZ48eaIvv/xSBw8eVFdXl3744Qe9//77Gh8fX9Rbjn0f5K34zw9rbS9fmlmIRqPq7OzUxMSEIpGIenp6VFNTo3379qmoqEh79+7Vnj17kt43m7OQSDkLHyQJwL/TfwhCKBTSgQMHNDU1NXesoKBAV69eTXoisy5duqQTJ05ox44dikajys/PT/p9P/30k5qbm/Xq1at5+weDQbW2tqZ9fpLk20IAWEtbvjSz4Pf7FQ6HU95eWVmphw8fJr0tm7OQSDELjv8KsH//ft29e1ft7e169OiRysvLdfz4cfl8vgXvN/u2yXPnzqU8Yen1pU9/f7/a29s1Pj6uiooKffXVV6qtrV38k3R4bsBiXbhwQbdu3Up5e11dXcrbVsMs5Kk0yRXAE3c+BmlqakolJSWqra1Vb2+vK4/xNt+/uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKeyJC8Bfs+NT0L1beUlAGtpy5cjs5BIMQu8FRiwIMUsEADAgkwC8F5ljlw6EwAs0WCOz0JuXwEAWBABAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAxLGoBXW2ey/0xc4PudumFp6nJkFhIpZiG3rwBy+dyATKSYBQIAWEAAAMMIAGCYGwGYnJzUzZs3NTo6qtLSUjU3N8vj8TjfMInp6Wndu3dPf/75pz799NPM7kwAkEXT09OKRCJKJBKqr693Zf/lngXHARgbG1NjY6NisdjcMa/Xq3A4rG3btjnb9I0//vhDwWBQoVBIfX19evHihb755hsCgFXn2bNn835Wnz9/rpMnTy5bANyeBccBCAQCisVi2r59u5qamnT79m1Fo1EdPnxYAwMDKiwsdLaxpJaWFvX09Di+/xwCAJe1traqq6vLtf3dngVHAejv79edO3dUVlamSCQij8ejRCKhXbt2aWhoSDdu3FBLS4vj59rW1qaKigo1NDTo119/1XfffedsIwIAlx05ckRer1f19fUaGRnR+fPnl3V/t2chX3lvbnx7pXH9+nVJ0qlTp+Ze869bt06nT5+WJF27ds3Zk3zjiy++UEdHhwKBgLZs2eJ8o2TnxmJlstI4evSoOjo6dOzYMZWWlqa/Q4bcngVHVwAjIyOSpJ07d847XlNTI0m6f/++8ye6nBycG5CTUsyCowA8ffpUkrRp06Z5x0tKSiS9/sXIqkAAgNeWMwBrRi6fG5CJ5QzA+vXrJUnxeHze8dmvi4uLM9/UDQQAeC3FLDj6JWB5ebkk6cGDB/OOz3691PcBLJuV/gUSa+2vXJHi/BwFoKmpSZJ0+fJlzcz89e+SV65ckST5/f4F7x8Oh9Xd3a3h4eGMzyMjK/3Dw1r7y2UrPQt5eqGZvx9PeBb+H+h4PK7q6mo9fvxYgUBAhw4dUigU0sWLF+XxeDQ+Pq6NGzcmve/o6KiqqqokScFgUG1tbe98z9DQkH788UdNTEzo3r176u3t1ccffyy/36+ioiJ99tlnamhoSHvOvpd5K/7zw1rby5dmFqLRqDo7OzUxMaFIJKKenh7V1NRo3759Kioq0t69e7Vnz56k983mLCRSzsLLJAHYkP5DEEKhkA4cOKCpqam5YwUFBbp69WrSE5l16dIlnThxQjt27FA0GlV+fv4739PQ0KBffvkl5R5VVVX67bff0j5H338JAGtpy5dmFvx+v8LhcMrbKysr9fDhw6S3ZXMWEilmwfFfAfbv36+7d++qvb1djx49Unl5uY4fPy6fz7fg/WbfNnnu3LmkJyxJ33//vbq7u1Pu8cknnyzuSTo8N2CxLly4oFu3bqW8va6uLuVtq2EW8hRPcgXwD3c+BmlqakolJSWqra1Vb2+vK4/xNt//uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKfJJC8BinLjk1B9U7wEYC1t+XJkFhIpZoG3AgMWpJgFAgBYkEkA3pvOkUtnAoAlGszxWcjtKwAACyIAgGEEADCMAACG/R+qH8xoau6KiAAAAABJRU5ErkJggg==`,
-        });
+		this.samplers.push({
+			magFilter: 9729,
+			minFilter: 9987,
+			wrapS: 33648,
+			wrapT: 33648,
+		});
 
-        this.samplers.push({
-            magFilter: 9729,
-            minFilter: 9987,
-            wrapS: 33648,
-            wrapT: 33648
-        });
+		this.materials.push({
+			pbrMetallicRoughness: {
+				baseColorTexture: {
+					index: 0,
+				},
+				metallicFactor: 0.0,
+				roughnessFactor: 1.0,
+			},
+		});
 
-        this.materials.push({
-            pbrMetallicRoughness : {
-              baseColorTexture : {
-                index : 0
-              },
-              metallicFactor : 0.0,
-              roughnessFactor : 1.0
-            }
-        });
-        
-        let buffersAmount = this.buffers.length;
-        this.buffers.push({
-            uri: "data:application/gltf-buffer;base64," + base64.bytesToBase64(uvBytes),
-            byteLength: uvBytes.length,
-        });
+		let buffersAmount = this.buffers.length;
+		this.buffers.push({
+			uri:
+				"data:application/gltf-buffer;base64," + base64.bytesToBase64(uvBytes),
+			byteLength: uvBytes.length,
+		});
 
-        this.bufferViews.push({
-            buffer: buffersAmount,
-            byteOffset: 0,
-            target : 34962,
-            byteLength: uvBytes.length,
-        });
+		this.bufferViews.push({
+			buffer: buffersAmount,
+			byteOffset: 0,
+			target: 34962,
+			byteLength: uvBytes.length,
+		});
 
-        this.accessors.push({
-            bufferView: buffersAmount,
-            byteOffset: 0,
-            componentType: 5126,
-            count: uvs.length,
-            type: "VEC2",
-            max: [1.0, 1.0],
-            min: [0.0, 0.0]
-        });
+		this.accessors.push({
+			bufferView: buffersAmount,
+			byteOffset: 0,
+			componentType: 5126,
+			count: uvs.length,
+			type: "VEC2",
+			max: [1.0, 1.0],
+			min: [0.0, 0.0],
+		});
 
-        this.meshes[0].primitives[0].attributes.TEXCOORD_0 = this.accessors.length - 1;
-        this.meshes[0].primitives[0].material = 0;
-    }
+		this.meshes[0].primitives[0].attributes.TEXCOORD_0 =
+			this.accessors.length - 1;
+		this.meshes[0].primitives[0].material = 0;
+	}
 }
 
 export default class GLTFExporter {
+	verticies = [];
+	morphTargetsAmount = 0;
 
-    verticies = [];
-    morphTargetsAmount = 0;
+	constructor(def) {
+		this.file = new GLTFFile();
 
-    constructor(def) {
-        this.file = new GLTFFile();
+		this.verticies = [];
+		for (let i = 0; i < def.vertexPositionsX.length; i++) {
+			this.verticies.push([
+				def.vertexPositionsX[i],
+				-def.vertexPositionsY[i],
+				-def.vertexPositionsZ[i],
+			]);
+		}
 
-        this.verticies = [];
-        for (let i = 0; i < def.vertexPositionsX.length; i++) {
-            this.verticies.push([def.vertexPositionsX[i], -def.vertexPositionsY[i], -def.vertexPositionsZ[i]]);
-        }
+		let indicies = [];
+		for (let i = 0; i < def.faceVertexIndices1.length; i++) {
+			indicies.push([
+				def.faceVertexIndices1[i],
+				def.faceVertexIndices2[i],
+				def.faceVertexIndices3[i],
+			]);
+		}
 
-        let indicies = [];
-        for (let i = 0; i < def.faceVertexIndices1.length; i++) {
-            indicies.push([def.faceVertexIndices1[i], def.faceVertexIndices2[i], def.faceVertexIndices3[i]]);
-        }
+		this.file.addIndicies(indicies);
+		this.file.addVerticies(this.verticies);
+	}
 
-        this.file.addIndicies(indicies);
-        this.file.addVerticies(this.verticies);
-    }
+	addMorphTarget(morphVertices) {
+		for (let i = 0; i < morphVertices.length; i++) {
+			morphVertices[i][0] = this.verticies[i][0] + i;
+			morphVertices[i][1] = this.verticies[i][1] + i;
+			morphVertices[i][2] = this.verticies[i][2] + i;
+		}
 
-    addMorphTarget(morphVertices) {
-        for (let i = 0; i < morphVertices.length; i++) {
-            morphVertices[i][0] -= this.verticies[i][0];
-            morphVertices[i][1] -= this.verticies[i][1];
-            morphVertices[i][2] -= this.verticies[i][2];
-        }
+		this.morphTargetsAmount++;
+		this.file.addMorphTarget(morphVertices);
+	}
 
-        this.morphTargetsAmount++;
-        this.file.addMorphTarget(morphVertices);
-    }
+	addAnimation(def) {
+		let frames = def.frameIDs.map((x) => x & 65535);
+		let lengths = Object.assign([], def.frameLengths);
+		for (let i = 1; i < lengths.length; i++) {
+			lengths[i] += lengths[i - 1];
+		}
+		lengths = lengths.map((x) => x / 50);
+		this.file.addAnimation(frames, lengths, this.morphTargetsAmount);
+	}
 
-    addAnimation(def) {
-        let frames = def.frameIDs.map(x => x & 65535);
-        let lengths = Object.assign([], def.frameLengths);
-        for (let i = 1; i < lengths.length; i++) {
-            lengths[i] += lengths[i - 1];
-        }
-        lengths = lengths.map(x => x / 50);
-        this.file.addAnimation(frames, lengths, this.morphTargetsAmount);
-    }
+	addColors(def) {
+		let uvs = new Array(988).fill().map((x) => [Math.random(), Math.random()]);
+		uvs[0] = [1, 1];
+		uvs[1] = [0, 0];
+		this.file.addColors(uvs);
+	}
 
-    addColors(def) {
-        let uvs = new Array(988).fill().map(x => [Math.random(), Math.random()]);
-        uvs[0] = [1,1];
-        uvs[1] = [0,0];
-        this.file.addColors(uvs);
-    }
-
-    export() {
-        return JSON.stringify(this.file);
-    }
-
+	export() {
+		return JSON.stringify(this.file);
+	}
 }

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -1,5 +1,55 @@
 import * as base64 from "../helpers/base64.js"
-import { isBrowser } from "browser-or-node";
+
+import { createCanvas } from "canvas";
+
+function HSVtoRGB(h, s, v) {
+	let r, g, b, i, f, p, q, t;
+	if (arguments.length === 1) {
+		s = h.s,
+		v = h.v,
+		h = h.h;
+	}
+	i = Math.floor(h * 6);
+	f = h * 6 - i;
+	p = v * (1 - s);
+	q = v * (1 - f * s);
+	t = v * (1 - (1 - f) * s);
+	switch (i % 6) {
+	case 0:
+		r = v,
+		g = t,
+		b = p;
+		break;
+	case 1:
+		r = q,
+		g = v,
+		b = p;
+		break;
+	case 2:
+		r = p,
+		g = v,
+		b = t;
+		break;
+	case 3:
+		r = p,
+		g = q,
+		b = v;
+		break;
+	case 4:
+		r = t,
+		g = p,
+		b = v;
+		break;
+	case 5:
+		r = v,
+		g = p,
+		b = q;
+		break;
+	}
+	//IT MUST BE * 255 AND ROUNDED INORDER TO GET THE CORRECT NUMBERS
+	return [Math.round(r * 255) / 255, Math.round(g * 255) / 255, Math.round(b * 255) / 255];
+
+}
 
 class GLTFFile {
     //Basically just setting it up for 1 model
@@ -223,7 +273,7 @@ class GLTFFile {
         });
     }
 
-    addColors(uvs) {
+    addColors(uvs, colorPalettePng) {
         let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
 
         const texturesAmount = this.textures.length;
@@ -233,8 +283,8 @@ class GLTFFile {
         });
 
         this.images.push({
-            uri: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAwaSURBVHic7dxfSJT5Hsfxj39a49jQlnA2z5gKa+FVS8nqLKxWs4V4ERgkWLJNu9DeBNEu23UE3QQbe9GSdeFFMNFlIBuLjTprm6E0MghLSDtauBHnXMT258xRGxfPRenmNuM4jz6jzvf9gt+Fzzi/mQf8vnlGx8mTNJMnicVi2VuFyhMAowgAYBgBAAwjAIBhBAAwLGkAXk3NZP+ZuMBXRN2wNHU5MguJFLOQ21cAuXxuQCZSzAIBACwgAIBhBAAwzI0ATE5O6ubNmxodHVVpaamam5vl8Xicb/g3ExMTc/t7vV41Nzdrw4YNi9+AACCLpqenFYlElEgkVF9fv6x7uzULjgMwNjamxsZGxWKxuWNer1fhcFjbtm1ztulbYrGYGhsbNTY2Nnds69atCofD+vDDDxe3CQGAy549e6ZgMKhQKKS+vj49f/5cJ0+eXNYAuDkLjgMQCAQUi8W0fft2NTU16fbt24pGozp8+LAGBgZUWFjobOM3Pv/8c42Njam6ulqNjY36+eefNTw8rLa2NvX396ugoCD9JgQALmttbVVXV5erj+HmLDgKQH9/v+7cuaOysjJFIhF5PB4lEgnt2rVLQ0NDunHjhlpaWjLf+I2+vj4NDAyooqJCkUhExcXFSiQS+uijjzQ4OKjOzk4dPHgw/UYEAC47cuSIvF6v6uvrNTIyovPnzy/r/m7PQn7S/xFM4/r165KkU6dOzb3mX7dunU6fPi1JunbtWvpNFrH/119/reLi4rn9v/3228z2X+n/tWSt/ZXG0aNH1dHRoWPHjqm0tDT9HTLk9iw4ugIYGRmRJO3cuXPe8ZqaGknS/fv3M9/Ujf0dnBuwmrg9C44C8PTpU0nSpk2b5h0vKSmR9PoXI0uxbPsTAKxxbs8C7wMALFjOAKxfv16SFI/H5x2f/Xr2tYpTy7Y/AcAa5/YsOPolYHl5uSTpwYMH847Pfr3U9wEs2/4r/Qsk1tpfK8ztWXAUgKamJknS5cuXNTPz179LXrlyRZLk9/sXvH84HFZ3d7eGh4cX3L+9vX3e8cXuP2elf3hYa3+5bKVnIU//fPdTgRP/Wfh/oOPxuKqrq/X48WMFAgEdOnRIoVBIFy9elMfj0fj4uDZu3Jj0vqOjo6qqqpIkBYNBtbW1vfM9L1++VHV1tZ48eaIvv/xSBw8eVFdXl3744Qe9//77Gh8fX9Rbjn0f5K34zw9rbS9fmlmIRqPq7OzUxMSEIpGIenp6VFNTo3379qmoqEh79+7Vnj17kt43m7OQSDkLHyQJwL/TfwhCKBTSgQMHNDU1NXesoKBAV69eTXoisy5duqQTJ05ox44dikajys/PT/p9P/30k5qbm/Xq1at5+weDQbW2tqZ9fpLk20IAWEtbvjSz4Pf7FQ6HU95eWVmphw8fJr0tm7OQSDELjv8KsH//ft29e1ft7e169OiRysvLdfz4cfl8vgXvN/u2yXPnzqU8Yen1pU9/f7/a29s1Pj6uiooKffXVV6qtrV38k3R4bsBiXbhwQbdu3Up5e11dXcrbVsMs5Kk0yRXAE3c+BmlqakolJSWqra1Vb2+vK4/xNt+/uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKeyJC8Bfs+NT0L1beUlAGtpy5cjs5BIMQu8FRiwIMUsEADAgkwC8F5ljlw6EwAs0WCOz0JuXwEAWBABAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAxLGoBXW2ey/0xc4PudumFp6nJkFhIpZiG3rwBy+dyATKSYBQIAWEAAAMMIAGCYGwGYnJzUzZs3NTo6qtLSUjU3N8vj8TjfMInp6Wndu3dPf/75pz799NPM7kwAkEXT09OKRCJKJBKqr693Zf/lngXHARgbG1NjY6NisdjcMa/Xq3A4rG3btjnb9I0//vhDwWBQoVBIfX19evHihb755hsCgFXn2bNn835Wnz9/rpMnTy5bANyeBccBCAQCisVi2r59u5qamnT79m1Fo1EdPnxYAwMDKiwsdLaxpJaWFvX09Di+/xwCAJe1traqq6vLtf3dngVHAejv79edO3dUVlamSCQij8ejRCKhXbt2aWhoSDdu3FBLS4vj59rW1qaKigo1NDTo119/1XfffedsIwIAlx05ckRer1f19fUaGRnR+fPnl3V/t2chX3lvbnx7pXH9+nVJ0qlTp+Ze869bt06nT5+WJF27ds3Zk3zjiy++UEdHhwKBgLZs2eJ8o2TnxmJlstI4evSoOjo6dOzYMZWWlqa/Q4bcngVHVwAjIyOSpJ07d847XlNTI0m6f/++8ye6nBycG5CTUsyCowA8ffpUkrRp06Z5x0tKSiS9/sXIqkAAgNeWMwBrRi6fG5CJ5QzA+vXrJUnxeHze8dmvi4uLM9/UDQQAeC3FLDj6JWB5ebkk6cGDB/OOz3691PcBLJuV/gUSa+2vXJHi/BwFoKmpSZJ0+fJlzcz89e+SV65ckST5/f4F7x8Oh9Xd3a3h4eGMzyMjK/3Dw1r7y2UrPQt5eqGZvx9PeBb+H+h4PK7q6mo9fvxYgUBAhw4dUigU0sWLF+XxeDQ+Pq6NGzcmve/o6KiqqqokScFgUG1tbe98z9DQkH788UdNTEzo3r176u3t1ccffyy/36+ioiJ99tlnamhoSHvOvpd5K/7zw1rby5dmFqLRqDo7OzUxMaFIJKKenh7V1NRo3759Kioq0t69e7Vnz56k983mLCRSzsLLJAHYkP5DEEKhkA4cOKCpqam5YwUFBbp69WrSE5l16dIlnThxQjt27FA0GlV+fv4739PQ0KBffvkl5R5VVVX67bff0j5H338JAGtpy5dmFvx+v8LhcMrbKysr9fDhw6S3ZXMWEilmwfFfAfbv36+7d++qvb1djx49Unl5uY4fPy6fz7fg/WbfNnnu3LmkJyxJ33//vbq7u1Pu8cknnyzuSTo8N2CxLly4oFu3bqW8va6uLuVtq2EW8hRPcgXwD3c+BmlqakolJSWqra1Vb2+vK4/xNt//uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKfJJC8BinLjk1B9U7wEYC1t+XJkFhIpZoG3AgMWpJgFAgBYkEkA3pvOkUtnAoAlGszxWcjtKwAACyIAgGEEADCMAACG/R+qH8xoau6KiAAAAABJRU5ErkJggg==`,
-        });
+            uri: colorPalettePng
+		});
 
         this.samplers.push({
             magFilter: 9729,
@@ -325,10 +375,52 @@ export default class GLTFExporter {
     }
 
     addColors(def) {
-        let uvs = new Array(988).fill().map(x => [Math.random(), Math.random()]);
-        uvs[0] = [1,1];
-        uvs[1] = [0,0];
-        this.file.addColors(uvs);
+		const faceColors = {};
+		const colorToPaletteIndex = {};
+		for (let i = 0; i < def.faceColors.length; ++i) {
+			if (faceColors[def.faceColors[i]]) {
+				continue;
+			}
+			let rscolor = def.faceColors[i];
+			let hue = (rscolor >> 10) & 0x3f;
+			let saturation = (rscolor >> 7) & 0x07;
+			let brightness = (rscolor & 0x7f);
+			let color = HSVtoRGB(hue / 63, saturation / 7, brightness / 127);
+			faceColors[def.faceColors[i]] = color;
+			colorToPaletteIndex[def.faceColors[i]] = Object.keys(faceColors).length - 1;
+		}
+		const numUniqueColors = Object.keys(faceColors).length;
+		// create a texture for the face colors
+		const pSize = 10;
+		const canvas = createCanvas(numUniqueColors * pSize, pSize, "png");
+		const ctx = canvas.getContext('2d');
+		let xx = 0;
+		for (const rgb of Object.values(faceColors)) {
+			ctx.fillStyle = `rgb(${rgb[0] * 255}, ${rgb[1] * 255}, ${rgb[2] * 255})`;
+			ctx.fillRect(xx, 0, pSize, pSize);
+			xx += pSize;
+		}
+		const colorPalettePng = canvas.toDataURL();
+
+		// TODO: this is not right - we need to duplicate vertex positions
+        let uvs = new Array(def.vertexPositionsX.length);
+		for (let i = 0; i < def.faceColors.length; ++i) {
+			const faceColor = def.faceColors[i];
+			const v1 = def.faceVertexIndices1[i];
+			const v2 = def.faceVertexIndices2[i];
+			const v3 = def.faceVertexIndices3[i];
+			const paletteIndex = colorToPaletteIndex[faceColor];
+			if (!uvs[v1]) {
+				uvs[v1] = [paletteIndex / numUniqueColors, 0];
+			}
+			if (!uvs[v2]) {
+				uvs[v2] = [paletteIndex / numUniqueColors, 0];
+			}
+			if (!uvs[v3]) {
+				uvs[v3] = [paletteIndex / numUniqueColors, 0];
+			}
+		}
+        this.file.addColors(uvs, colorPalettePng, colorToPaletteIndex);
     }
 
     export() {

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -170,7 +170,7 @@ class GLTFFile {
 
         let max = indicies
             .flat()
-            .reduce((max, current) => Math.max(max, current));
+            .reduce((max, current) => Math.max(max, current), 0);
         this.accessors.push({
             bufferView: buffersAmount,
             byteOffset: 0,
@@ -487,7 +487,7 @@ export default class GLTFExporter {
 		const vertexColorPairs = {};
 		const alphaVertexColorPairs = {};
         for (let i = 0; i < def.faceVertexIndices1.length; i++) {
-			const alpha = def.faceAlphas[i];
+			const alpha = def.faceAlphas[i] ?? 0;
             const isAlpha = alpha !== 0;
             const dest = isAlpha ? this.alphaVertices : this.verticies;
 			const destIndices = isAlpha ? alphaIndices : indices;
@@ -579,7 +579,7 @@ export default class GLTFExporter {
         for (let i = 0; i < def.faceColors.length; ++i) {
             const lookupIndex = this.combineColorAndAlpha(
                 def.faceColors[i],
-				def.faceAlphas[i]
+				def.faceAlphas[i] ?? 0
             );
             // ensure unique color + alpha combinations
             if (seenColors[lookupIndex]) {
@@ -590,7 +590,7 @@ export default class GLTFExporter {
             let r = ((color >> 16) & 0xff) / 255.0;
             let g = ((color >> 8) & 0xff) / 255.0;
             let b = (color & 0xff) / 255.0;
-            let a = def.faceAlphas[i];
+            let a = def.faceAlphas[i] ?? 0;
             let rscolorWithAlpha = this.combineColorAndAlpha(
                 color,
 				a
@@ -625,7 +625,7 @@ export default class GLTFExporter {
         for (let i = 0; i < this.faces.length; i++) {
             let faceId = this.faces[i];
             const faceColor = def.faceColors[faceId];
-            const faceAlpha = def.faceAlphas[faceId];
+            const faceAlpha = def.faceAlphas[faceId] ?? 0;
             const lookupKey = this.combineColorAndAlpha(faceColor, faceAlpha);
             const paletteIndex = colorToPaletteIndex[lookupKey];
 			// remap to new position within the vertices based on its color and alpha
@@ -642,7 +642,7 @@ export default class GLTFExporter {
         for (let i = 0; i < this.alphaFaces.length; i++) {
             let faceId = this.alphaFaces[i];
             const faceColor = def.faceColors[faceId];
-            const faceAlpha = def.faceAlphas[faceId];
+            const faceAlpha = def.faceAlphas[faceId] ?? 0;
             const lookupKey = this.combineColorAndAlpha(faceColor, faceAlpha);
             const paletteIndex = colorToPaletteIndex[lookupKey];
 			// remap to new position within the vertices based on its color and alpha

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -2,375 +2,337 @@ import * as base64 from "../helpers/base64.js"
 import { isBrowser } from "browser-or-node";
 
 class GLTFFile {
-	//Basically just setting it up for 1 model
-	scene = 0;
-	scenes = [{ nodes: [0] }];
+    //Basically just setting it up for 1 model
+    scene = 0;
+    scenes = [
+        { nodes: [0] }
+    ];
 
-	nodes = [{ mesh: 0 }];
+    nodes = [{ mesh: 0 }];
 
-	meshes = [
-		{
-			primitives: [
-				{
-					attributes: {
-						POSITION: 1,
-					},
-					indices: 0,
-				},
-			],
-		},
-	];
+    meshes = [
+        {
+            primitives: [{
+                attributes: {
+                    POSITION: 1
+                },
+                indices: 0,
+            }]
+        }
+    ];
 
-	textures = [];
-	images = [];
-	samplers = [];
-	materials = [];
-	animations = [];
+    textures = [];
+    images = [];
+    samplers = [];
+    materials = [];
+    animations = [];
 
-	buffers = [];
-	bufferViews = [];
+    buffers = [];
+    bufferViews = [];
 
-	accessors = [];
+    accessors = [];
 
-	asset = {
-		version: "2.0",
-	};
+    asset = {
+        version: "2.0"
+    };
 
-	addIndicies(indicies) {
-		let indicesBytes = new Uint8Array(new Uint16Array(indicies.flat()).buffer);
-		let buffersAmount = this.buffers.length;
-		this.buffers.push({
-			uri:
-				"data:application/octet-stream;base64," +
-				base64.bytesToBase64(indicesBytes),
-			byteLength: indicesBytes.length,
-		});
+    addIndicies(indicies) {
+        let indicesBytes = new Uint8Array(new Uint16Array(indicies.flat()).buffer)
+        let buffersAmount = this.buffers.length;
+        this.buffers.push({
+            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(indicesBytes),
+            byteLength: indicesBytes.length,
+        });
 
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: 0,
-			byteLength: indicesBytes.length,
-			target: 34963,
-		});
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: 0,
+            byteLength: indicesBytes.length,
+            target: 34963
+        });
 
-		let max = indicies.flat().reduce((max, current) => Math.max(max, current));
-		this.accessors.push({
-			bufferView: 0,
-			byteOffset: 0,
-			componentType: 5123,
-			count: indicesBytes.length / 2,
-			type: "SCALAR",
-			max: [max],
-			min: [0],
-		});
-	}
+        let max = indicies.flat().reduce((max, current) => Math.max(max, current));
+        this.accessors.push({
+            bufferView: 0,
+            byteOffset: 0,
+            componentType: 5123,
+            count: indicesBytes.length / 2,
+            type: "SCALAR",
+            max: [max],
+            min: [0]
+        });
+    }
 
-	addVerticies(verticies) {
-		let max = [0, 0, 0];
-		let min = [0, 0, 0];
-		for (let i = 0; i < verticies.length; i++) {
-			max = [
-				Math.max(max[0], verticies[i][0]),
-				Math.max(max[1], verticies[i][1]),
-				Math.max(max[2], verticies[i][2]),
-			];
-			min = [
-				Math.min(min[0], verticies[i][0]),
-				Math.min(min[1], verticies[i][1]),
-				Math.min(min[2], verticies[i][2]),
-			];
-		}
+    addVerticies(verticies) {
+        let max = [0, 0, 0];
+        let min = [0, 0, 0];
+        for (let i = 0; i < verticies.length; i++) {
+            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
+            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
+        }
 
-		let verticiesBytes = new Uint8Array(
-			new Float32Array(verticies.flat()).buffer
-		);
+        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
 
-		let buffersAmount = this.buffers.length;
-		this.buffers.push({
-			uri:
-				"data:application/octet-stream;base64," +
-				base64.bytesToBase64(verticiesBytes),
-			byteLength: verticiesBytes.length,
-		});
 
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: 0,
-			byteLength: verticiesBytes.length,
-		});
+        let buffersAmount = this.buffers.length;
+        this.buffers.push({
+            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
+            byteLength: verticiesBytes.length,
+        });
 
-		this.accessors.push({
-			bufferView: buffersAmount,
-			byteOffset: 0,
-			componentType: 5126,
-			count: verticies.length,
-			type: "VEC3",
-			max,
-			min,
-		});
-	}
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: 0,
+            byteLength: verticiesBytes.length,
+        });
 
-	addMorphTarget(verticies) {
-		let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
-		let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
-		for (let i = 0; i < verticies.length; i++) {
-			max = [
-				Math.max(max[0], verticies[i][0]),
-				Math.max(max[1], verticies[i][1]),
-				Math.max(max[2], verticies[i][2]),
-			];
-			min = [
-				Math.min(min[0], verticies[i][0]),
-				Math.min(min[1], verticies[i][1]),
-				Math.min(min[2], verticies[i][2]),
-			];
-		}
+        this.accessors.push({
+            bufferView: buffersAmount,
+            byteOffset: 0,
+            componentType: 5126,
+            count: verticies.length,
+            type: "VEC3",
+            max,
+            min
+        });
+    }
 
-		let verticiesBytes = new Uint8Array(
-			new Float32Array(verticies.flat()).buffer
-		);
+    addMorphTarget(verticies) {
+        //verticies.forEach(x => x[2] *= -1);
+        let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
+        let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
+        for (let i = 0; i < verticies.length; i++) {
+            max = [Math.max(max[0], verticies[i][0]), Math.max(max[1], verticies[i][1]), Math.max(max[2], verticies[i][2])];
+            min = [Math.min(min[0], verticies[i][0]), Math.min(min[1], verticies[i][1]), Math.min(min[2], verticies[i][2])];
+        }
 
-		if (!("targets" in this.meshes[0].primitives[0])) {
-			this.meshes[0].primitives[0].targets = [];
-			this.meshes[0].weights = [];
-		}
+        let verticiesBytes = new Uint8Array(new Float32Array(verticies.flat()).buffer)
 
-		let buffersAmount = this.buffers.length;
+        if (!("targets" in this.meshes[0].primitives[0])) {
+            this.meshes[0].primitives[0].targets = [];
+            this.meshes[0].weights = [];
+        }
 
-		if (this.meshes[0].weights.length == 0) {
-			this.meshes[0].weights.push(1);
-		} else {
-			this.meshes[0].weights.push(0);
-		}
-		this.meshes[0].primitives[0].targets.push({ POSITION: buffersAmount });
+        let buffersAmount = this.buffers.length;
 
-		this.buffers.push({
-			uri:
-				"data:application/octet-stream;base64," +
-				base64.bytesToBase64(verticiesBytes),
-			byteLength: verticiesBytes.length,
-		});
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: 0,
-			byteLength: verticiesBytes.length,
-			target: 34962,
-		});
+        if (this.meshes[0].weights.length == 0) {
+            this.meshes[0].weights.push(1);
+        } else {
+            this.meshes[0].weights.push(0);
+        }
+        this.meshes[0].primitives[0].targets.push({ "POSITION": buffersAmount });
 
-		this.accessors.push({
-			bufferView: buffersAmount,
-			byteOffset: 0,
-			componentType: 5126,
-			count: verticies.length,
-			type: "VEC3",
-			max,
-			min,
-		});
+        this.buffers.push({
+            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(verticiesBytes),
+            byteLength: verticiesBytes.length,
+        });
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: 0,
+            byteLength: verticiesBytes.length,
+            target: 34962
+        });
 
-		//animations needs to be adjusted if more morph targets are added after anims
-	}
+        this.accessors.push({
+            bufferView: buffersAmount,
+            byteOffset: 0,
+            componentType: 5126,
+            count: verticies.length,
+            type: "VEC3",
+            max,
+            min
+        });
 
-	addAnimation(targets, lengths, morphTargetsAmount) {
-		targets = targets.map((x) => {
-			let oneHot = new Array(morphTargetsAmount).fill(0);
-			oneHot[x] = 1;
-			return oneHot;
-		}); //one hot encoding
+        //animations needs to be adjusted if more morph targets are added after anims
+    }
 
-		let targetBytes = new Uint8Array(new Float32Array(targets.flat()).buffer);
-		let lengthsBytes = new Uint8Array(new Float32Array(lengths).buffer);
+    addAnimation(targets, lengths, morphTargetsAmount) {
+        targets = targets.map(x => {
+            let oneHot = new Array(morphTargetsAmount).fill(0)
+            oneHot[x] = 1;
+            return oneHot
+        }); //one hot encoding
 
-		let mergedBytes = new Uint8Array(lengthsBytes.length + targetBytes.length);
-		mergedBytes.set(lengthsBytes);
-		mergedBytes.set(targetBytes, lengthsBytes.length);
+        let targetBytes = new Uint8Array(new Float32Array(targets.flat()).buffer);
+        let lengthsBytes = new Uint8Array(new Float32Array(lengths).buffer);
 
-		let buffersAmount = this.buffers.length;
-		this.buffers.push({
-			uri:
-				"data:application/octet-stream;base64," +
-				base64.bytesToBase64(mergedBytes),
-			byteLength: mergedBytes.length,
-		});
+        let mergedBytes = new Uint8Array(lengthsBytes.length + targetBytes.length);
+        mergedBytes.set(lengthsBytes);
+        mergedBytes.set(targetBytes, lengthsBytes.length);
 
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: 0,
-			byteLength: lengthsBytes.length,
-		});
+        let buffersAmount = this.buffers.length;
+        this.buffers.push({
+            uri: "data:application/octet-stream;base64," + base64.bytesToBase64(mergedBytes),
+            byteLength: mergedBytes.length,
+        });
 
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: lengthsBytes.length,
-			byteLength: targetBytes.length,
-		});
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: 0,
+            byteLength: lengthsBytes.length,
+        });
 
-		let max = lengths[0];
-		let min = lengths[0];
-		for (let i = 0; i < lengths.length; i++) {
-			max = Math.max(max, lengths[i]);
-			min = Math.min(min, lengths[i]);
-		}
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: lengthsBytes.length,
+            byteLength: targetBytes.length,
+        });
 
-		let accessorsLength = this.accessors.length;
-		this.accessors.push({
-			bufferView: this.bufferViews.length - 2,
-			byteOffset: 0,
-			componentType: 5126,
-			count: targets.length,
-			type: "SCALAR",
-			max: [max],
-			min: [min],
-		});
+        let max = lengths[0];
+        let min = lengths[0];
+        for (let i = 0; i < lengths.length; i++) {
+            max = Math.max(max, lengths[i]);
+            min = Math.min(min, lengths[i]);
+        }
 
-		this.accessors.push({
-			bufferView: this.bufferViews.length - 1,
-			byteOffset: 0,
-			componentType: 5126,
-			count: morphTargetsAmount * targets.length,
-			type: "SCALAR",
-			max: [1.0],
-			min: [0.0],
-		});
+        let accessorsLength = this.accessors.length;
+        this.accessors.push({
+            bufferView: this.bufferViews.length - 2,
+            byteOffset: 0,
+            componentType: 5126,
+            count: targets.length,
+            type: "SCALAR",
+            max: [max],
+            min: [min]
+        });
 
-		let animationsLength = this.animations.length;
-		this.animations.push({
-			samplers: [
-				{
-					input: accessorsLength,
-					interpolation: "STEP",
-					output: accessorsLength + 1,
-				},
-			],
-			channels: [
-				{
-					sampler: 0,
-					target: {
-						node: 0,
-						path: "weights",
-					},
-				},
-			],
-		});
-	}
+        this.accessors.push({
+            bufferView: this.bufferViews.length - 1,
+            byteOffset: 0,
+            componentType: 5126,
+            count: morphTargetsAmount * targets.length,
+            type: "SCALAR",
+            max: [1.0],
+            min: [0.0]
+        });
 
-	addColors(uvs) {
-		let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
+        let animationsLength = this.animations.length;
+        this.animations.push({
+            samplers: [{
+                input: accessorsLength,
+                interpolation: "STEP",
+                output: accessorsLength + 1
+            }],
+            channels: [{
+                sampler: 0,
+                target: {
+                    node: 0,
+                    path: "weights"
+                }
+            }]
+        });
+    }
 
-		const texturesAmount = this.textures.length;
-		this.textures.push({
-			source: texturesAmount,
-			sampler: texturesAmount,
-		});
+    addColors(uvs) {
+        let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
 
-		this.images.push({
-			uri: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAwaSURBVHic7dxfSJT5Hsfxj39a49jQlnA2z5gKa+FVS8nqLKxWs4V4ERgkWLJNu9DeBNEu23UE3QQbe9GSdeFFMNFlIBuLjTprm6E0MghLSDtauBHnXMT258xRGxfPRenmNuM4jz6jzvf9gt+Fzzi/mQf8vnlGx8mTNJMnicVi2VuFyhMAowgAYBgBAAwjAIBhBAAwLGkAXk3NZP+ZuMBXRN2wNHU5MguJFLOQ21cAuXxuQCZSzAIBACwgAIBhBAAwzI0ATE5O6ubNmxodHVVpaamam5vl8Xicb/g3ExMTc/t7vV41Nzdrw4YNi9+AACCLpqenFYlElEgkVF9fv6x7uzULjgMwNjamxsZGxWKxuWNer1fhcFjbtm1ztulbYrGYGhsbNTY2Nnds69atCofD+vDDDxe3CQGAy549e6ZgMKhQKKS+vj49f/5cJ0+eXNYAuDkLjgMQCAQUi8W0fft2NTU16fbt24pGozp8+LAGBgZUWFjobOM3Pv/8c42Njam6ulqNjY36+eefNTw8rLa2NvX396ugoCD9JgQALmttbVVXV5erj+HmLDgKQH9/v+7cuaOysjJFIhF5PB4lEgnt2rVLQ0NDunHjhlpaWjLf+I2+vj4NDAyooqJCkUhExcXFSiQS+uijjzQ4OKjOzk4dPHgw/UYEAC47cuSIvF6v6uvrNTIyovPnzy/r/m7PQn7S/xFM4/r165KkU6dOzb3mX7dunU6fPi1JunbtWvpNFrH/119/reLi4rn9v/3228z2X+n/tWSt/ZXG0aNH1dHRoWPHjqm0tDT9HTLk9iw4ugIYGRmRJO3cuXPe8ZqaGknS/fv3M9/Ujf0dnBuwmrg9C44C8PTpU0nSpk2b5h0vKSmR9PoXI0uxbPsTAKxxbs8C7wMALFjOAKxfv16SFI/H5x2f/Xr2tYpTy7Y/AcAa5/YsOPolYHl5uSTpwYMH847Pfr3U9wEs2/4r/Qsk1tpfK8ztWXAUgKamJknS5cuXNTPz179LXrlyRZLk9/sXvH84HFZ3d7eGh4cX3L+9vX3e8cXuP2elf3hYa3+5bKVnIU//fPdTgRP/Wfh/oOPxuKqrq/X48WMFAgEdOnRIoVBIFy9elMfj0fj4uDZu3Jj0vqOjo6qqqpIkBYNBtbW1vfM9L1++VHV1tZ48eaIvv/xSBw8eVFdXl3744Qe9//77Gh8fX9Rbjn0f5K34zw9rbS9fmlmIRqPq7OzUxMSEIpGIenp6VFNTo3379qmoqEh79+7Vnj17kt43m7OQSDkLHyQJwL/TfwhCKBTSgQMHNDU1NXesoKBAV69eTXoisy5duqQTJ05ox44dikajys/PT/p9P/30k5qbm/Xq1at5+weDQbW2tqZ9fpLk20IAWEtbvjSz4Pf7FQ6HU95eWVmphw8fJr0tm7OQSDELjv8KsH//ft29e1ft7e169OiRysvLdfz4cfl8vgXvN/u2yXPnzqU8Yen1pU9/f7/a29s1Pj6uiooKffXVV6qtrV38k3R4bsBiXbhwQbdu3Up5e11dXcrbVsMs5Kk0yRXAE3c+BmlqakolJSWqra1Vb2+vK4/xNt+/uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKeyJC8Bfs+NT0L1beUlAGtpy5cjs5BIMQu8FRiwIMUsEADAgkwC8F5ljlw6EwAs0WCOz0JuXwEAWBABAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAxLGoBXW2ey/0xc4PudumFp6nJkFhIpZiG3rwBy+dyATKSYBQIAWEAAAMMIAGCYGwGYnJzUzZs3NTo6qtLSUjU3N8vj8TjfMInp6Wndu3dPf/75pz799NPM7kwAkEXT09OKRCJKJBKqr693Zf/lngXHARgbG1NjY6NisdjcMa/Xq3A4rG3btjnb9I0//vhDwWBQoVBIfX19evHihb755hsCgFXn2bNn835Wnz9/rpMnTy5bANyeBccBCAQCisVi2r59u5qamnT79m1Fo1EdPnxYAwMDKiwsdLaxpJaWFvX09Di+/xwCAJe1traqq6vLtf3dngVHAejv79edO3dUVlamSCQij8ejRCKhXbt2aWhoSDdu3FBLS4vj59rW1qaKigo1NDTo119/1XfffedsIwIAlx05ckRer1f19fUaGRnR+fPnl3V/t2chX3lvbnx7pXH9+nVJ0qlTp+Ze869bt06nT5+WJF27ds3Zk3zjiy++UEdHhwKBgLZs2eJ8o2TnxmJlstI4evSoOjo6dOzYMZWWlqa/Q4bcngVHVwAjIyOSpJ07d847XlNTI0m6f/++8ye6nBycG5CTUsyCowA8ffpUkrRp06Z5x0tKSiS9/sXIqkAAgNeWMwBrRi6fG5CJ5QzA+vXrJUnxeHze8dmvi4uLM9/UDQQAeC3FLDj6JWB5ebkk6cGDB/OOz3691PcBLJuV/gUSa+2vXJHi/BwFoKmpSZJ0+fJlzcz89e+SV65ckST5/f4F7x8Oh9Xd3a3h4eGMzyMjK/3Dw1r7y2UrPQt5eqGZvx9PeBb+H+h4PK7q6mo9fvxYgUBAhw4dUigU0sWLF+XxeDQ+Pq6NGzcmve/o6KiqqqokScFgUG1tbe98z9DQkH788UdNTEzo3r176u3t1ccffyy/36+ioiJ99tlnamhoSHvOvpd5K/7zw1rby5dmFqLRqDo7OzUxMaFIJKKenh7V1NRo3759Kioq0t69e7Vnz56k983mLCRSzsLLJAHYkP5DEEKhkA4cOKCpqam5YwUFBbp69WrSE5l16dIlnThxQjt27FA0GlV+fv4739PQ0KBffvkl5R5VVVX67bff0j5H338JAGtpy5dmFvx+v8LhcMrbKysr9fDhw6S3ZXMWEilmwfFfAfbv36+7d++qvb1djx49Unl5uY4fPy6fz7fg/WbfNnnu3LmkJyxJ33//vbq7u1Pu8cknnyzuSTo8N2CxLly4oFu3bqW8va6uLuVtq2EW8hRPcgXwD3c+BmlqakolJSWqra1Vb2+vK4/xNt//uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKfJJC8BinLjk1B9U7wEYC1t+XJkFhIpZoG3AgMWpJgFAgBYkEkA3pvOkUtnAoAlGszxWcjtKwAACyIAgGEEADCMAACG/R+qH8xoau6KiAAAAABJRU5ErkJggg==`,
-		});
+        const texturesAmount = this.textures.length;
+        this.textures.push({
+            source: texturesAmount,
+            sampler: texturesAmount
+        });
 
-		this.samplers.push({
-			magFilter: 9729,
-			minFilter: 9987,
-			wrapS: 33648,
-			wrapT: 33648,
-		});
+        this.images.push({
+            uri: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAwaSURBVHic7dxfSJT5Hsfxj39a49jQlnA2z5gKa+FVS8nqLKxWs4V4ERgkWLJNu9DeBNEu23UE3QQbe9GSdeFFMNFlIBuLjTprm6E0MghLSDtauBHnXMT258xRGxfPRenmNuM4jz6jzvf9gt+Fzzi/mQf8vnlGx8mTNJMnicVi2VuFyhMAowgAYBgBAAwjAIBhBAAwLGkAXk3NZP+ZuMBXRN2wNHU5MguJFLOQ21cAuXxuQCZSzAIBACwgAIBhBAAwzI0ATE5O6ubNmxodHVVpaamam5vl8Xicb/g3ExMTc/t7vV41Nzdrw4YNi9+AACCLpqenFYlElEgkVF9fv6x7uzULjgMwNjamxsZGxWKxuWNer1fhcFjbtm1ztulbYrGYGhsbNTY2Nnds69atCofD+vDDDxe3CQGAy549e6ZgMKhQKKS+vj49f/5cJ0+eXNYAuDkLjgMQCAQUi8W0fft2NTU16fbt24pGozp8+LAGBgZUWFjobOM3Pv/8c42Njam6ulqNjY36+eefNTw8rLa2NvX396ugoCD9JgQALmttbVVXV5erj+HmLDgKQH9/v+7cuaOysjJFIhF5PB4lEgnt2rVLQ0NDunHjhlpaWjLf+I2+vj4NDAyooqJCkUhExcXFSiQS+uijjzQ4OKjOzk4dPHgw/UYEAC47cuSIvF6v6uvrNTIyovPnzy/r/m7PQn7S/xFM4/r165KkU6dOzb3mX7dunU6fPi1JunbtWvpNFrH/119/reLi4rn9v/3228z2X+n/tWSt/ZXG0aNH1dHRoWPHjqm0tDT9HTLk9iw4ugIYGRmRJO3cuXPe8ZqaGknS/fv3M9/Ujf0dnBuwmrg9C44C8PTpU0nSpk2b5h0vKSmR9PoXI0uxbPsTAKxxbs8C7wMALFjOAKxfv16SFI/H5x2f/Xr2tYpTy7Y/AcAa5/YsOPolYHl5uSTpwYMH847Pfr3U9wEs2/4r/Qsk1tpfK8ztWXAUgKamJknS5cuXNTPz179LXrlyRZLk9/sXvH84HFZ3d7eGh4cX3L+9vX3e8cXuP2elf3hYa3+5bKVnIU//fPdTgRP/Wfh/oOPxuKqrq/X48WMFAgEdOnRIoVBIFy9elMfj0fj4uDZu3Jj0vqOjo6qqqpIkBYNBtbW1vfM9L1++VHV1tZ48eaIvv/xSBw8eVFdXl3744Qe9//77Gh8fX9Rbjn0f5K34zw9rbS9fmlmIRqPq7OzUxMSEIpGIenp6VFNTo3379qmoqEh79+7Vnj17kt43m7OQSDkLHyQJwL/TfwhCKBTSgQMHNDU1NXesoKBAV69eTXoisy5duqQTJ05ox44dikajys/PT/p9P/30k5qbm/Xq1at5+weDQbW2tqZ9fpLk20IAWEtbvjSz4Pf7FQ6HU95eWVmphw8fJr0tm7OQSDELjv8KsH//ft29e1ft7e169OiRysvLdfz4cfl8vgXvN/u2yXPnzqU8Yen1pU9/f7/a29s1Pj6uiooKffXVV6qtrV38k3R4bsBiXbhwQbdu3Up5e11dXcrbVsMs5Kk0yRXAE3c+BmlqakolJSWqra1Vb2+vK4/xNt+/uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKeyJC8Bfs+NT0L1beUlAGtpy5cjs5BIMQu8FRiwIMUsEADAgkwC8F5ljlw6EwAs0WCOz0JuXwEAWBABAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAwjAIBhBAAwjAAAhhEAwDACABhGAADDCABgGAEADCMAgGEEADCMAACGEQDAMAIAGEYAAMMIAGAYAQAMIwCAYQQAMIwAAIYRAMAwAgAYRgAAwwgAYBgBAAxLGoBXW2ey/0xc4PudumFp6nJkFhIpZiG3rwBy+dyATKSYBQIAWEAAAMMIAGCYGwGYnJzUzZs3NTo6qtLSUjU3N8vj8TjfMInp6Wndu3dPf/75pz799NPM7kwAkEXT09OKRCJKJBKqr693Zf/lngXHARgbG1NjY6NisdjcMa/Xq3A4rG3btjnb9I0//vhDwWBQoVBIfX19evHihb755hsCgFXn2bNn835Wnz9/rpMnTy5bANyeBccBCAQCisVi2r59u5qamnT79m1Fo1EdPnxYAwMDKiwsdLaxpJaWFvX09Di+/xwCAJe1traqq6vLtf3dngVHAejv79edO3dUVlamSCQij8ejRCKhXbt2aWhoSDdu3FBLS4vj59rW1qaKigo1NDTo119/1XfffedsIwIAlx05ckRer1f19fUaGRnR+fPnl3V/t2chX3lvbnx7pXH9+nVJ0qlTp+Ze869bt06nT5+WJF27ds3Zk3zjiy++UEdHhwKBgLZs2eJ8o2TnxmJlstI4evSoOjo6dOzYMZWWlqa/Q4bcngVHVwAjIyOSpJ07d847XlNTI0m6f/++8ye6nBycG5CTUsyCowA8ffpUkrRp06Z5x0tKSiS9/sXIqkAAgNeWMwBrRi6fG5CJ5QzA+vXrJUnxeHze8dmvi4uLM9/UDQQAeC3FLDj6JWB5ebkk6cGDB/OOz3691PcBLJuV/gUSa+2vXJHi/BwFoKmpSZJ0+fJlzcz89e+SV65ckST5/f4F7x8Oh9Xd3a3h4eGMzyMjK/3Dw1r7y2UrPQt5eqGZvx9PeBb+H+h4PK7q6mo9fvxYgUBAhw4dUigU0sWLF+XxeDQ+Pq6NGzcmve/o6KiqqqokScFgUG1tbe98z9DQkH788UdNTEzo3r176u3t1ccffyy/36+ioiJ99tlnamhoSHvOvpd5K/7zw1rby5dmFqLRqDo7OzUxMaFIJKKenh7V1NRo3759Kioq0t69e7Vnz56k983mLCRSzsLLJAHYkP5DEEKhkA4cOKCpqam5YwUFBbp69WrSE5l16dIlnThxQjt27FA0GlV+fv4739PQ0KBffvkl5R5VVVX67bff0j5H338JAGtpy5dmFvx+v8LhcMrbKysr9fDhw6S3ZXMWEilmwfFfAfbv36+7d++qvb1djx49Unl5uY4fPy6fz7fg/WbfNnnu3LmkJyxJ33//vbq7u1Pu8cknnyzuSTo8N2CxLly4oFu3bqW8va6uLuVtq2EW8hRPcgXwD3c+BmlqakolJSWqra1Vb2+vK4/xNt//uAJgLW35cmQWEilmIavvAxgcHFQ8HteZM2ey84BZPDcgE6tlFrIagM2bN+vs2bPavXt3dh6QAGCVWi2zkKfJJC8BinLjk1B9U7wEYC1t+XJkFhIpZoG3AgMWpJgFAgBYkEkA3pvOkUtnAoAlGszxWcjtKwAACyIAgGEEADCMAACG/R+qH8xoau6KiAAAAABJRU5ErkJggg==`,
+        });
 
-		this.materials.push({
-			pbrMetallicRoughness: {
-				baseColorTexture: {
-					index: 0,
-				},
-				metallicFactor: 0.0,
-				roughnessFactor: 1.0,
-			},
-		});
+        this.samplers.push({
+            magFilter: 9729,
+            minFilter: 9987,
+            wrapS: 33648,
+            wrapT: 33648
+        });
 
-		let buffersAmount = this.buffers.length;
-		this.buffers.push({
-			uri:
-				"data:application/gltf-buffer;base64," + base64.bytesToBase64(uvBytes),
-			byteLength: uvBytes.length,
-		});
+        this.materials.push({
+            pbrMetallicRoughness : {
+              baseColorTexture : {
+                index : 0
+              },
+              metallicFactor : 0.0,
+              roughnessFactor : 1.0
+            }
+        });
+        
+        let buffersAmount = this.buffers.length;
+        this.buffers.push({
+            uri: "data:application/gltf-buffer;base64," + base64.bytesToBase64(uvBytes),
+            byteLength: uvBytes.length,
+        });
 
-		this.bufferViews.push({
-			buffer: buffersAmount,
-			byteOffset: 0,
-			target: 34962,
-			byteLength: uvBytes.length,
-		});
+        this.bufferViews.push({
+            buffer: buffersAmount,
+            byteOffset: 0,
+            target : 34962,
+            byteLength: uvBytes.length,
+        });
 
-		this.accessors.push({
-			bufferView: buffersAmount,
-			byteOffset: 0,
-			componentType: 5126,
-			count: uvs.length,
-			type: "VEC2",
-			max: [1.0, 1.0],
-			min: [0.0, 0.0],
-		});
+        this.accessors.push({
+            bufferView: buffersAmount,
+            byteOffset: 0,
+            componentType: 5126,
+            count: uvs.length,
+            type: "VEC2",
+            max: [1.0, 1.0],
+            min: [0.0, 0.0]
+        });
 
-		this.meshes[0].primitives[0].attributes.TEXCOORD_0 =
-			this.accessors.length - 1;
-		this.meshes[0].primitives[0].material = 0;
-	}
+        this.meshes[0].primitives[0].attributes.TEXCOORD_0 = this.accessors.length - 1;
+        this.meshes[0].primitives[0].material = 0;
+    }
 }
 
 export default class GLTFExporter {
-	verticies = [];
-	morphTargetsAmount = 0;
 
-	constructor(def) {
-		this.file = new GLTFFile();
+    verticies = [];
+    morphTargetsAmount = 0;
 
-		this.verticies = [];
-		for (let i = 0; i < def.vertexPositionsX.length; i++) {
-			this.verticies.push([
-				def.vertexPositionsX[i],
-				-def.vertexPositionsY[i],
-				-def.vertexPositionsZ[i],
-			]);
-		}
+    constructor(def) {
+        this.file = new GLTFFile();
 
-		let indicies = [];
-		for (let i = 0; i < def.faceVertexIndices1.length; i++) {
-			indicies.push([
-				def.faceVertexIndices1[i],
-				def.faceVertexIndices2[i],
-				def.faceVertexIndices3[i],
-			]);
-		}
+        this.verticies = [];
+        for (let i = 0; i < def.vertexPositionsX.length; i++) {
+            this.verticies.push([def.vertexPositionsX[i], -def.vertexPositionsY[i], -def.vertexPositionsZ[i]]);
+        }
 
-		this.file.addIndicies(indicies);
-		this.file.addVerticies(this.verticies);
-	}
+        let indicies = [];
+        for (let i = 0; i < def.faceVertexIndices1.length; i++) {
+            indicies.push([def.faceVertexIndices1[i], def.faceVertexIndices2[i], def.faceVertexIndices3[i]]);
+        }
 
-	addMorphTarget(morphVertices) {
-		for (let i = 0; i < morphVertices.length; i++) {
-			morphVertices[i][0] = this.verticies[i][0] + i;
-			morphVertices[i][1] = this.verticies[i][1] + i;
-			morphVertices[i][2] = this.verticies[i][2] + i;
-		}
+        this.file.addIndicies(indicies);
+        this.file.addVerticies(this.verticies);
+    }
 
-		this.morphTargetsAmount++;
-		this.file.addMorphTarget(morphVertices);
-	}
+    addMorphTarget(morphVertices) {
+        for (let i = 0; i < morphVertices.length; i++) {
+            morphVertices[i][0] -= this.verticies[i][0];
+            morphVertices[i][1] -= this.verticies[i][1];
+            morphVertices[i][2] -= this.verticies[i][2];
+        }
 
-	addAnimation(def) {
-		let frames = def.frameIDs.map((x) => x & 65535);
-		let lengths = Object.assign([], def.frameLengths);
-		for (let i = 1; i < lengths.length; i++) {
-			lengths[i] += lengths[i - 1];
-		}
-		lengths = lengths.map((x) => x / 50);
-		this.file.addAnimation(frames, lengths, this.morphTargetsAmount);
-	}
+        this.morphTargetsAmount++;
+        this.file.addMorphTarget(morphVertices);
+    }
 
-	addColors(def) {
-		let uvs = new Array(988).fill().map((x) => [Math.random(), Math.random()]);
-		uvs[0] = [1, 1];
-		uvs[1] = [0, 0];
-		this.file.addColors(uvs);
-	}
+    addAnimation(def) {
+        let frames = def.frameIDs.map(x => x & 65535);
+        let lengths = Object.assign([], def.frameLengths);
+        for (let i = 1; i < lengths.length; i++) {
+            lengths[i] += lengths[i - 1];
+        }
+        lengths = lengths.map(x => x / 50);
+        this.file.addAnimation(frames, lengths, this.morphTargetsAmount);
+    }
 
-	export() {
-		return JSON.stringify(this.file);
-	}
+    addColors(def) {
+        let uvs = new Array(988).fill().map(x => [Math.random(), Math.random()]);
+        uvs[0] = [1,1];
+        uvs[1] = [0,0];
+        this.file.addColors(uvs);
+    }
+
+    export() {
+        return JSON.stringify(this.file);
+    }
+
 }

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -1,134 +1,129 @@
-import * as base64 from "../helpers/base64.js"
+import * as base64 from "../helpers/base64.js";
 
 import { createCanvas } from "canvas";
 
 function HSVtoRGB(h, s, v) {
-	let r, g, b, i, f, p, q, t;
-	if (arguments.length === 1) {
-		s = h.s,
-		v = h.v,
-		h = h.h;
-	}
-	i = Math.floor(h * 6);
-	f = h * 6 - i;
-	p = v * (1 - s);
-	q = v * (1 - f * s);
-	t = v * (1 - (1 - f) * s);
-	switch (i % 6) {
-	case 0:
-		r = v,
-		g = t,
-		b = p;
-		break;
-	case 1:
-		r = q,
-		g = v,
-		b = p;
-		break;
-	case 2:
-		r = p,
-		g = v,
-		b = t;
-		break;
-	case 3:
-		r = p,
-		g = q,
-		b = v;
-		break;
-	case 4:
-		r = t,
-		g = p,
-		b = v;
-		break;
-	case 5:
-		r = v,
-		g = p,
-		b = q;
-		break;
-	}
-	//IT MUST BE * 255 AND ROUNDED INORDER TO GET THE CORRECT NUMBERS
-	return [Math.round(r * 255) / 255, Math.round(g * 255) / 255, Math.round(b * 255) / 255];
-
+    let r, g, b, i, f, p, q, t;
+    if (arguments.length === 1) {
+        (s = h.s), (v = h.v), (h = h.h);
+    }
+    i = Math.floor(h * 6);
+    f = h * 6 - i;
+    p = v * (1 - s);
+    q = v * (1 - f * s);
+    t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0:
+            (r = v), (g = t), (b = p);
+            break;
+        case 1:
+            (r = q), (g = v), (b = p);
+            break;
+        case 2:
+            (r = p), (g = v), (b = t);
+            break;
+        case 3:
+            (r = p), (g = q), (b = v);
+            break;
+        case 4:
+            (r = t), (g = p), (b = v);
+            break;
+        case 5:
+            (r = v), (g = p), (b = q);
+            break;
+    }
+    //IT MUST BE * 255 AND ROUNDED INORDER TO GET THE CORRECT NUMBERS
+    return [
+        Math.round(r * 255) / 255,
+        Math.round(g * 255) / 255,
+        Math.round(b * 255) / 255,
+    ];
 }
 
 const BRIGHTNESS_MAX = 0.6;
-const HUE_OFFSET = (0.5 / 64);
-const SATURATION_OFFSET = (0.5 / 8);
+const HUE_OFFSET = 0.5 / 64;
+const SATURATION_OFFSET = 0.5 / 8;
 
 function unpackHue(hsl) {
-	return hsl >> 10 & 63;
+    return (hsl >> 10) & 63;
 }
 
 function unpackSaturation(hsl) {
-	return hsl >> 7 & 7;
+    return (hsl >> 7) & 7;
 }
 
 function unpackLuminance(hsl) {
-	return hsl & 127;
+    return hsl & 127;
 }
 
 function HSLtoRGB(hsl, brightness) {
-	let hue = unpackHue(hsl) / 64 + HUE_OFFSET;
-	let saturation = unpackSaturation(hsl) / 8 + SATURATION_OFFSET;
-	let luminance = unpackLuminance(hsl) / 128;
+    let hue = unpackHue(hsl) / 64 + HUE_OFFSET;
+    let saturation = unpackSaturation(hsl) / 8 + SATURATION_OFFSET;
+    let luminance = unpackLuminance(hsl) / 128;
 
-	let chroma = (1 - Math.abs((2 * luminance) - 1)) * saturation;
-	let x = chroma * (1 - Math.abs(((hue * 6) % 2) - 1));
-	let lightness = luminance - (chroma / 2);
+    let chroma = (1 - Math.abs(2 * luminance - 1)) * saturation;
+    let x = chroma * (1 - Math.abs(((hue * 6) % 2) - 1));
+    let lightness = luminance - chroma / 2;
 
-	let r = lightness
-	  , g = lightness
-	  , b = lightness;
+    let r = lightness,
+        g = lightness,
+        b = lightness;
 
-	switch (parseInt(hue * 6)) {
-	case 0:
-		r += chroma;
-		g += x;
-		break;
-	case 1:
-		g += chroma;
-		r += x;
-		break;
-	case 2:
-		g += chroma;
-		b += x;
-		break;
-	case 3:
-		b += chroma;
-		g += x;
-		break;
-	case 4:
-		b += chroma;
-		r += x;
-		break;
-	default:
-		r += chroma;
-		b += x;
-		break;
-	}
+    switch (parseInt(hue * 6)) {
+        case 0:
+            r += chroma;
+            g += x;
+            break;
+        case 1:
+            g += chroma;
+            r += x;
+            break;
+        case 2:
+            g += chroma;
+            b += x;
+            break;
+        case 3:
+            b += chroma;
+            g += x;
+            break;
+        case 4:
+            b += chroma;
+            r += x;
+            break;
+        default:
+            r += chroma;
+            b += x;
+            break;
+    }
 
-	let rgb = (parseInt(r * 256.0) << 16) | (parseInt(g * 256.0) << 8) | parseInt(b * 256.0);
+    let rgb =
+        (parseInt(r * 256.0) << 16) |
+        (parseInt(g * 256.0) << 8) |
+        parseInt(b * 256.0);
 
-	rgb = adjustForBrightness(rgb, brightness);
+    rgb = adjustForBrightness(rgb, brightness);
 
-	if (rgb == 0) {
-		rgb = 1;
-	}
-	return rgb;
+    if (rgb == 0) {
+        rgb = 1;
+    }
+    return rgb;
 }
 
 function adjustForBrightness(rgb, brightness) {
-	let r = (rgb >> 16) / 256.0;
-	let g = (rgb >> 8 & 255) / 256.0;
-	let b = (rgb & 255) / 256.0;
+    let r = (rgb >> 16) / 256.0;
+    let g = ((rgb >> 8) & 255) / 256.0;
+    let b = (rgb & 255) / 256.0;
 
-	r = Math.pow(r, brightness);
-	g = Math.pow(g, brightness);
-	b = Math.pow(b, brightness);
+    r = Math.pow(r, brightness);
+    g = Math.pow(g, brightness);
+    b = Math.pow(b, brightness);
 
-	return (parseInt(r * 256.0) << 16) | (parseInt((g * 256.0)) << 8) | parseInt((b * 256.0));
+    return (
+        (parseInt(r * 256.0) << 16) |
+        (parseInt(g * 256.0) << 8) |
+        parseInt(b * 256.0)
+    );
 }
-
 
 class GLTFFile {
     //Basically just setting it up for 1 model
@@ -137,18 +132,7 @@ class GLTFFile {
 
     nodes = [{ mesh: 0 }];
 
-    meshes = [
-        {
-            primitives: [
-                {
-                    attributes: {
-                        POSITION: 0,
-                    },
-                    //indices: 0,
-                },
-            ],
-        },
-    ];
+    meshes = [{ primitives: [] }];
 
     textures = [];
     images = [];
@@ -188,7 +172,7 @@ class GLTFFile {
             .flat()
             .reduce((max, current) => Math.max(max, current));
         this.accessors.push({
-            bufferView: 0,
+            bufferView: buffersAmount,
             byteOffset: 0,
             componentType: 5123,
             count: indicesBytes.length / 2,
@@ -198,7 +182,14 @@ class GLTFFile {
         });
     }
 
+	// assume the indices are added right before the vertices
     addVerticies(verticies) {
+        this.meshes[0].primitives.push({
+            attributes: {
+                POSITION: this.buffers.length,
+            },
+			indices: this.buffers.length - 1,
+        });
         let max = [0, 0, 0];
         let min = [0, 0, 0];
         for (let i = 0; i < verticies.length; i++) {
@@ -243,7 +234,7 @@ class GLTFFile {
         });
     }
 
-    addMorphTarget(verticies) {
+    addMorphTarget(verticies, primitive) {
         let max = [verticies[0][0], verticies[0][1], verticies[0][2]];
         let min = [verticies[0][0], verticies[0][1], verticies[0][2]];
         for (let i = 0; i < verticies.length; i++) {
@@ -263,19 +254,23 @@ class GLTFFile {
             new Float32Array(verticies.flat()).buffer
         );
 
-        if (!("targets" in this.meshes[0].primitives[0])) {
-            this.meshes[0].primitives[0].targets = [];
-            this.meshes[0].weights = [];
+        if (!("targets" in this.meshes[0].primitives[primitive])) {
+            this.meshes[0].primitives[primitive].targets = [];
+            this.meshes[0].weights = [0];
         }
 
         let buffersAmount = this.buffers.length;
 
-        if (this.meshes[0].weights.length == 0) {
-            this.meshes[0].weights.push(1);
-        } else {
-            this.meshes[0].weights.push(0);
-        }
-        this.meshes[0].primitives[0].targets.push({ POSITION: buffersAmount });
+		if (primitive === 0) {
+			if (this.meshes[0].weights.length == 0) {
+				this.meshes[0].weights.push(1);
+			} else {
+				this.meshes[0].weights.push(0);
+			}
+		}
+        this.meshes[0].primitives[primitive].targets.push({
+            POSITION: buffersAmount,
+        });
 
         this.buffers.push({
             uri:
@@ -390,18 +385,20 @@ class GLTFFile {
         });
     }
 
-    addColors(uvs, colorPalettePng) {
+    addColors(uvs, colorPalettePng, primitive, transparent = false) {
         let uvBytes = new Uint8Array(new Float32Array(uvs.flat()).buffer);
 
-        const texturesAmount = this.textures.length;
-        this.textures.push({
-            source: texturesAmount,
-            sampler: texturesAmount,
-        });
+		if (colorPalettePng) {
+			const texturesAmount = this.textures.length;
+			this.textures.push({
+				source: texturesAmount,
+				sampler: texturesAmount,
+			});
 
-        this.images.push({
-            uri: colorPalettePng,
-        });
+			this.images.push({
+				uri: colorPalettePng,
+			});
+		}
 
         this.samplers.push({
             magFilter: 9728,
@@ -411,8 +408,8 @@ class GLTFFile {
         });
 
         this.materials.push({
+            ...(transparent && { alphaMode: "BLEND" }),
             pbrMetallicRoughness: {
-                baseColorFactor: [1.0, 1.0, 1.0, 1.0],
                 baseColorTexture: {
                     index: 0,
                 },
@@ -452,63 +449,117 @@ class GLTFFile {
             min,
         });
 
-        this.meshes[0].primitives[0].attributes.TEXCOORD_0 =
+        this.meshes[0].primitives[primitive].attributes.TEXCOORD_0 =
             this.accessors.length - 1;
-        this.meshes[0].primitives[0].material = 0;
+        this.meshes[0].primitives[primitive].material =
+            this.materials.length - 1;
     }
 }
 
 export default class GLTFExporter {
+    // regular (non-alpha) vertices
     verticies = [];
+    // regular (non-alpha) faces
+    faces = [];
+    alphaVertices = [];
+    alphaFaces = [];
     morphTargetsAmount = 0;
 
+    /**
+     * mapping of original vertex ID to new vertex IDs
+     * if alpha is true, it refers to the position in this.alphaVertices, otherwise this.verticies
+     * @type {[originalIdx: number]: {[colorKey: number]: {idx: number, alpha: boolean}}
+     */
     remappedVertices = {};
+	
+	combineColorAndAlpha = (color, alpha) => (color & 0xffffff) | (alpha & 0xff) << 24;
 
     constructor(def) {
         this.file = new GLTFFile();
 
         this.verticies = [];
+        this.alphaVertices = [];
 
-        // n.b. we reorder the vertices by faces. this duplicates all of the vertices but allows us to
-        // apply per-face textures/colours and removes the need for indices.
+		// every {vertex + color} pair is deduplicated so that combination only appears once in the vertex buffer
+		let indices = [];
+		let alphaIndices = [];
+
+		const vertexColorPairs = {};
+		const alphaVertexColorPairs = {};
         for (let i = 0; i < def.faceVertexIndices1.length; i++) {
+			const alpha = def.faceAlphas[i];
+            const isAlpha = alpha !== 0;
+            const dest = isAlpha ? this.alphaVertices : this.verticies;
+			const destIndices = isAlpha ? alphaIndices : indices;
+			const destPairs = isAlpha ? alphaVertexColorPairs : vertexColorPairs;
+            if (isAlpha) {
+                this.alphaFaces.push(i);
+            } else {
+                this.faces.push(i);
+            }
             const v1 = def.faceVertexIndices1[i];
             const v2 = def.faceVertexIndices2[i];
             const v3 = def.faceVertexIndices3[i];
+			const color = def.faceColors[i];
+			// for deduplication
+			const pairKey = this.combineColorAndAlpha(color, alpha);
             const faceVertices = [v1, v2, v3];
             faceVertices.forEach((idx, pos) => {
-                this.verticies.push([
-                    def.vertexPositionsX[idx],
-                    -def.vertexPositionsY[idx],
-                    -def.vertexPositionsZ[idx],
-                ]);
+				if (!(idx in destPairs)) {
+					destPairs[idx] = {};
+				}
+				if (!(pairKey in destPairs[idx])) {
+					// encountering this vertex-color pair for the first time
+					destPairs[idx][pairKey] = dest.length;
+					dest.push([
+						def.vertexPositionsX[idx],
+						-def.vertexPositionsY[idx],
+						-def.vertexPositionsZ[idx],
+					]);
+				}
+				const vertexIndex = destPairs[idx][pairKey];
+				destIndices.push(vertexIndex);
                 if (!(idx in this.remappedVertices)) {
-                    this.remappedVertices[idx] = [];
+                    this.remappedVertices[idx] = {};
                 }
-                // maintain a multimap of original vertex ID to where they are now in `this.verticies`.
-                this.remappedVertices[idx].push(i * 3 + pos);
+                // maintain a multimap of original vertex ID to where they are now in the destination vertex array. It is further keyed
+				// by the colour+alpha.
+                this.remappedVertices[idx][pairKey] = {
+                    idx: vertexIndex,
+					pairKey,
+                    alpha: isAlpha,
+                };
             });
         }
+		this.file.addIndicies(indices);
         this.file.addVerticies(this.verticies);
+        if (this.alphaVertices.length > 0) {
+			this.file.addIndicies(alphaIndices);
+			this.file.addVerticies(this.alphaVertices);
+		}
     }
 
     addMorphTarget(morphVertices) {
         let newMorphVertices = [];
+        let newAlphaMorphVertices = [];
         for (let i = 0; i < morphVertices.length; i++) {
             const realVertices = this.remappedVertices[i];
-            for (const realVertex of realVertices) {
-                newMorphVertices[realVertex] = [];
-                newMorphVertices[realVertex][0] =
-                    morphVertices[i][0] - this.verticies[realVertex][0];
-                newMorphVertices[realVertex][1] =
-                    morphVertices[i][1] - this.verticies[realVertex][1];
-                newMorphVertices[realVertex][2] =
-                    morphVertices[i][2] - this.verticies[realVertex][2];
+			// may end up reprocessing each vertex multiple times if it appears in multiple colours, but thats OK
+            for (const { idx: newIdx, alpha } of Object.values(realVertices)) {
+                const src = alpha ? this.alphaVertices : this.verticies;
+                const dest = alpha ? newAlphaMorphVertices : newMorphVertices;
+                dest[newIdx] = [];
+                dest[newIdx][0] = morphVertices[i][0] - src[newIdx][0];
+                dest[newIdx][1] = morphVertices[i][1] - src[newIdx][1];
+                dest[newIdx][2] = morphVertices[i][2] - src[newIdx][2];
             }
         }
 
         this.morphTargetsAmount++;
-        this.file.addMorphTarget(newMorphVertices);
+        this.file.addMorphTarget(newMorphVertices, 0);
+        if (this.alphaVertices.length > 0) {
+        	this.file.addMorphTarget(newAlphaMorphVertices, 1);
+		}
     }
 
     addAnimation(def) {
@@ -522,12 +573,16 @@ export default class GLTFExporter {
     }
 
     addColors(def) {
-        const faceColors = {};
+        const seenColors = {};
         const colorToPaletteIndex = {};
         const order = [];
-
         for (let i = 0; i < def.faceColors.length; ++i) {
-            if (faceColors[def.faceColors[i]]) {
+            const lookupIndex = this.combineColorAndAlpha(
+                def.faceColors[i],
+				def.faceAlphas[i]
+            );
+            // ensure unique color + alpha combinations
+            if (seenColors[lookupIndex]) {
                 continue;
             }
             let rscolor = def.faceColors[i];
@@ -535,38 +590,73 @@ export default class GLTFExporter {
             let r = ((color >> 16) & 0xff) / 255.0;
             let g = ((color >> 8) & 0xff) / 255.0;
             let b = (color & 0xff) / 255.0;
-            console.log(`rscolor ${rscolor} rgb ${r} ${g} ${b}`);
-            faceColors[rscolor] = color;
-            colorToPaletteIndex[rscolor] = Object.keys(faceColors).length - 1;
-            order.push(rscolor);
+            let a = def.faceAlphas[i];
+            let rscolorWithAlpha = this.combineColorAndAlpha(
+                color,
+				a
+            );
+            console.log(`rscolor ${rscolor} rgb ${r} ${g} ${b} ${a}`);
+            seenColors[lookupIndex] = color;
+            colorToPaletteIndex[lookupIndex] = order.length;
+            order.push(rscolorWithAlpha);
         }
-        const numUniqueColors = Object.keys(faceColors).length;
+        const numUniqueColors = Object.keys(seenColors).length;
         // create a texture for the face colors
-        const pSize = 16;
+        const pSize = 4;
         const canvas = createCanvas(numUniqueColors * pSize, pSize, "png");
         const ctx = canvas.getContext("2d");
         let xx = 0;
-        for (const rscolor of order) {
-            const rgb = faceColors[rscolor];
-            let r = (rgb >> 16) & 0xff;
-            let g = (rgb >> 8) & 0xff;
-            let b = rgb & 0xff;
-            ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+        for (const value of order) {
+            const a = (value >> 24) & 0xff;
+            let r = (value >> 16) & 0xff;
+            let g = (value >> 8) & 0xff;
+            let b = value & 0xff;
+            let alpha = 1 - a / 255;
+            ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+            console.log(`rgba ${r} ${g} ${b} ${alpha}`);
             ctx.fillRect(xx, 0, pSize, pSize);
             xx += pSize;
         }
         const colorPalettePng = canvas.toDataURL();
 
-        let uvs = new Array(def.faceColors.length * 3);
+        let normalUvs = new Array(this.verticies.length);
+        let alphaUvs = new Array(this.alphaVertices.length);
         const half = 1 / numUniqueColors / 2;
-        for (let i = 0; i < def.faceColors.length; ++i) {
-            const faceColor = def.faceColors[i];
-            const paletteIndex = colorToPaletteIndex[faceColor];
-            uvs[i * 3] = [paletteIndex / numUniqueColors + half, 0.33];
-            uvs[i * 3 + 1] = [paletteIndex / numUniqueColors + half, 0.5];
-            uvs[i * 3 + 2] = [paletteIndex / numUniqueColors + half, 0.66];
+        for (let i = 0; i < this.faces.length; i++) {
+            let faceId = this.faces[i];
+            const faceColor = def.faceColors[faceId];
+            const faceAlpha = def.faceAlphas[faceId];
+            const lookupKey = this.combineColorAndAlpha(faceColor, faceAlpha);
+            const paletteIndex = colorToPaletteIndex[lookupKey];
+			// remap to new position within the vertices based on its color and alpha
+			let v1 = this.remappedVertices[def.faceVertexIndices1[faceId]][lookupKey].idx;
+			let v2 = this.remappedVertices[def.faceVertexIndices2[faceId]][lookupKey].idx;
+			let v3 = this.remappedVertices[def.faceVertexIndices3[faceId]][lookupKey].idx;
+            normalUvs[v1] = [paletteIndex / numUniqueColors + half, 0.33];
+            normalUvs[v2] = [paletteIndex / numUniqueColors + half, 0.5];
+            normalUvs[v3] = [
+                paletteIndex / numUniqueColors + half,
+                0.66,
+            ];
         }
-        this.file.addColors(uvs, colorPalettePng, colorToPaletteIndex);
+        for (let i = 0; i < this.alphaFaces.length; i++) {
+            let faceId = this.alphaFaces[i];
+            const faceColor = def.faceColors[faceId];
+            const faceAlpha = def.faceAlphas[faceId];
+            const lookupKey = this.combineColorAndAlpha(faceColor, faceAlpha);
+            const paletteIndex = colorToPaletteIndex[lookupKey];
+			// remap to new position within the vertices based on its color and alpha
+			let v1 = this.remappedVertices[def.faceVertexIndices1[faceId]][lookupKey].idx;
+			let v2 = this.remappedVertices[def.faceVertexIndices2[faceId]][lookupKey].idx;
+			let v3 = this.remappedVertices[def.faceVertexIndices3[faceId]][lookupKey].idx;
+            alphaUvs[v1] = [paletteIndex / numUniqueColors + half, 0.33];
+            alphaUvs[v2] = [paletteIndex / numUniqueColors + half, 0.5];
+            alphaUvs[v3] = [paletteIndex / numUniqueColors + half, 0.66];
+        }
+        this.file.addColors(normalUvs, colorPalettePng, 0);
+        if (this.alphaVertices.length > 0) {
+			this.file.addColors(alphaUvs, null, 1, true);
+		}
     }
 
     export() {

--- a/src/cacheReader/loaders/FramesLoader.js
+++ b/src/cacheReader/loaders/FramesLoader.js
@@ -40,6 +40,8 @@ export class FramesDefinition {
 	/** @type {boolean} */
 	showing;
 
+    colorTransform;
+
     method727(var1, var2, var3) {
         let var5 = new Matrix();
 
@@ -230,8 +232,13 @@ export default class FramesLoader {
 
                 lastI = i;
                 ++index;
+                // alpha
                 if (def.framemap.types[i] == 5) {
                     def.showing = true;
+                }
+                if (def.framemap.types[i] == 7) {
+                    // color
+                    def.colorTransform = true;
                 }
             }
 

--- a/src/cacheReader/loaders/ModelLoader.js
+++ b/src/cacheReader/loaders/ModelLoader.js
@@ -356,7 +356,7 @@ export class ModelDefinition {
 	loadFrame(model, frame) {
 		let verticesX = [...model.vertexPositionsX];
 		let verticesY = [...model.vertexPositionsY];
-		let verticesZ = model.vertexPositionsZ.map(z => -z);
+		let verticesZ = [...model.vertexPositionsZ];
 		let framemap = frame.framemap;
 		let animOffsets = {
 			x: 0,

--- a/src/cacheReader/loaders/ModelLoader.js
+++ b/src/cacheReader/loaders/ModelLoader.js
@@ -1203,7 +1203,7 @@ export default class ModelLoader {
 			}
 
 			if (var14 == 1) {
-				def.faceAlphas[var51] = var5.readInt8();
+				def.faceAlphas[var51] = var5.readUint8();
 			}
 
 			if (var15 == 1) {

--- a/src/cacheReader/loaders/ModelLoader.js
+++ b/src/cacheReader/loaders/ModelLoader.js
@@ -982,7 +982,7 @@ export default class ModelLoader {
 		let var8 = new DataView(var1.buffer);
 		var2.setPosition(var1.byteLength - 26);
 		let var9 = var2.readUint16();
-		let var10 = var2.readUint16();
+		let numFaces = var2.readUint16();
 		let var11 = var2.readUint8();
 		let var12 = var2.readUint8();
 		let var13 = var2.readUint8();
@@ -1024,39 +1024,39 @@ export default class ModelLoader {
 		var28 = var11 + var9;
 		let var58 = var28;
 		if (var12 == 1) {
-			var28 += var10;
+			var28 += numFaces;
 		}
 
 		let var30 = var28;
-		var28 += var10;
+		var28 += numFaces;
 		let var31 = var28;
 		if (var13 == 255) {
-			var28 += var10;
+			var28 += numFaces;
 		}
 
 		let var32 = var28;
 		if (var15 == 1) {
-			var28 += var10;
+			var28 += numFaces;
 		}
 
 		let var33 = var28;
 		var28 += var24;
 		let var34 = var28;
 		if (var14 == 1) {
-			var28 += var10;
+			var28 += numFaces;
 		}
 
 		let var35 = var28;
 		var28 += var22;
 		let var36 = var28;
 		if (var16 == 1) {
-			var28 += var10 * 2;
+			var28 += numFaces * 2;
 		}
 
 		let var37 = var28;
 		var28 += var23;
 		let var38 = var28;
-		var28 += var10 * 2;
+		var28 += numFaces * 2;
 		let var39 = var28;
 		var28 += var19;
 		let var40 = var28;
@@ -1076,7 +1076,7 @@ export default class ModelLoader {
 		let var47 = var28;
 		var28 = var28 + var26 * 2 + var27 * 2;
 		def.vertexCount = var9;
-		def.faceCount = var10;
+		def.faceCount = numFaces;
 		def.numTextureFaces = var11;
 		def.vertexPositionsX = [];
 		def.vertexPositionsY = [];
@@ -1112,7 +1112,7 @@ export default class ModelLoader {
 		}
 
 		if (var16 == 1 && var11 > 0) {
-			def.textureCoords = new Array(var10).fill(0);
+			def.textureCoords = new Array(numFaces).fill(0);
 		}
 
 		if (var18 == 1) {
@@ -1192,7 +1192,7 @@ export default class ModelLoader {
 		var7.setPosition(var36);
 		var8.setPosition(var37);
 
-		for (var51 = 0; var51 < var10; ++var51) {
+		for (var51 = 0; var51 < numFaces; ++var51) {
 			def.faceColors[var51] = var2.readUint16();
 			if (var12 == 1) {
 				def.faceRenderTypes[var51] = var3.readInt8();
@@ -1227,7 +1227,7 @@ export default class ModelLoader {
 		var54 = 0;
 
 		let var56;
-		for (var55 = 0; var55 < var10; ++var55) {
+		for (var55 = 0; var55 < numFaces; ++var55) {
 			var56 = var3.readUint8();
 			if (var56 == 1) {
 				var51 = var2.readShortSmart() + var54;


### PR DESCRIPTION
NOTE: I changed `loadFrame` to not flip the Z coordinate... it seems to improve the animation export but I have no idea if it broke anything else.

Gif recorded from a GLTF viewer (https://gltf-viewer.donmccurdy.com/) from a Jad model exported by this tool.

![jad](https://github.com/Dezinater/osrscachereader/assets/1549353/cfb0f081-27a1-4f9d-9844-9ab86635513f)

