### PR TITLE
Don't use commas when writing vertices to OBJ files

### DIFF
--- a/src/cacheReader/exporters/OBJExporter.js
+++ b/src/cacheReader/exporters/OBJExporter.js
@@ -12,7 +12,7 @@ export default class OBJExporter {
             indicies.push([def.faceVertexIndices1[i], def.faceVertexIndices2[i], def.faceVertexIndices3[i]]);
         }
 
-        let verticiesString = verticies.map((x) => "v " + x.join(", ")).join("\n");
+        let verticiesString = verticies.map((x) => "v " + x.join(" ")).join("\n");
         let indiciesString = indicies.map((x) => "f " + x.map((y) => y + 1).join(" ")).join("\n");
         return verticiesString + "\n" + indiciesString;
     }


### PR DESCRIPTION
While using the [OSRS Entity Viewer](https://runemonk.com/tools/entityviewer-beta) I noticed that the exported OBJ files would not load properly when using an off-the-shelf OBJ loader (I'm using [`obj-rs`](https://github.com/simnalamburt/obj-rs), but I tested it with Blender and they don't load properly there either).

This PR removes the commas that were being used to separate the coordinates of each vertex in the file, as these are not valid in the format:

```
v x y z w

    Polygonal and free-form geometry statement.

    Specifies a geometric vertex and its x y z coordinates. Rational
    curves and surfaces require a fourth homogeneous coordinate, also
    called the weight.

    x y z are the x, y, and z coordinates for the vertex. These are
    floating point numbers that define the position of the vertex in
    three dimensions.

    w is the weight required for rational curves and surfaces. It is
    not required for non-rational curves and surfaces. If you do not
    specify a value for w, the default is 1.0.

    NOTE: A positive weight value is recommended. Using zero or
    negative values may result in an undefined point in a curve or
    surface.
```

— [source](https://paulbourke.net/dataformats/obj/)