### PR TITLE
Update addAnimation to properly calculate the first / last frame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "osrscachereader",
-    "version": "1.1.0",
+    "version": "1.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "osrscachereader",
-            "version": "1.1.0",
+            "version": "1.1.4",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@ledgerhq/compressjs": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "osrscachereader",
     "exports": "./src/index.js",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Read Old-School Runescape Cache files",
     "contributors": [
         {

--- a/src/cacheReader/exporters/GLTFExporter.js
+++ b/src/cacheReader/exporters/GLTFExporter.js
@@ -507,12 +507,24 @@ export default class GLTFExporter {
         return this.morphTargetsAmount++;
     }
 
+    /**
+     * @param {number[]} morphTargetIds 
+     * @param {number[]} baseLengths
+     * @param {string} name 
+     */
     addAnimation(morphTargetIds, baseLengths, name) {
-        let lengths = Object.assign([], baseLengths);
-        for (let i = 1; i < lengths.length; i++) {
-            lengths[i] += lengths[i - 1];
+        let cumulative = 0;
+        const lengths = new Array(baseLengths.length);
+        for (let i = 0; i < baseLengths.length; i++) {
+            lengths[i] = cumulative / 50;
+            cumulative += baseLengths[i];
         }
-        lengths = lengths.map((x) => x / 50);
+        // include the last frame's duration by appending an end timestamp
+        // and duplicating the final frame target so counts align
+        if (baseLengths.length > 0 && morphTargetIds.length > 0) {
+            lengths.push(cumulative / 50);
+            morphTargetIds = morphTargetIds.concat(morphTargetIds[morphTargetIds.length - 1]);
+        }
         this.animations.push({ morphTargetIds, lengths, name });
     }
 


### PR DESCRIPTION
Previously `addAnimation` placed the first keyframe at the position of the first offset. This should fix that to place the first keyframe at position 0, and additionally extending the last frame to be the proper length by duplicating the final frame and placing it at `finalFrame + finalFrameLength`.