### PR TITLE
fix: set rev229 for ModelGroup to load animations from KEYFRAMES

### DIFF
--- a/src/cacheReader/helpers/ModelGroup.js
+++ b/src/cacheReader/helpers/ModelGroup.js
@@ -23,6 +23,7 @@ export default class ModelGroup {
 
     mergeModels() {
         this.mergedModel = new ModelDefinition();
+        this.mergedModel.rev229 = this.models.some((model) => model.rev229);
         this.mergedModel.position = this.position;
         this.models.forEach(model => {
             


### PR DESCRIPTION
Before:
```
> osrscachereader@1.1.4 cmd
> node scripts/command.js modelBuilder exclude 52585 npc 12821 anim 10874 name sol3

Archive 419 does not exist
file:///mnt/c/Users/Supalosa/projects/osrscachereader/src/cacheReader/loaders/ModelLoader.js:808
            const rawVertexData = this.loadMayaAnimation(framesInfo[0].def, animation, invertZ);
                                                                   ^
```

Seems like rev229 now stores the keyframes in a different cache ID (22).

The `mergeModels` command dropped the revision information for the ModelGroup. Quick workaround is to use the rev229 flag based on the models passed into the ModelGroup.