### PR TITLE
Add reader-only package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "name": "osrscachereader",
-    "exports": "./src/index.js",
+    "exports": {
+        ".": "./src/index.js",
+        "./reader": "./src/reader.js"
+    },
     "version": "1.1.4",
     "description": "Read Old-School Runescape Cache files",
     "contributors": [

--- a/src/cacheReader/loaders/SpriteLoader.js
+++ b/src/cacheReader/loaders/SpriteLoader.js
@@ -1,5 +1,3 @@
-import { createCanvas } from "canvas";
-
 const FLAG_VERTICAL = 0b01;
 const FLAG_ALPHA = 0b10;
 /**
@@ -73,6 +71,7 @@ export class Sprite {
         if (width == undefined) width = this.getWidth();
         if (height == undefined) height = this.getHeight();
 
+        const { createCanvas } = await import("canvas");
         const canvas = createCanvas(this.getWidth(), this.getHeight());
         const ctx = canvas.getContext("2d");
 
@@ -98,10 +97,7 @@ export class Sprite {
     }
 
     createImageData(ctx) {
-        if (ctx == undefined) {
-            const canvas = createCanvas(this.getWidth(), this.getHeight());
-            ctx = canvas.getContext("2d");
-        }
+        if (ctx == undefined) throw new Error("Sprite image data requires a canvas context");
 
         let imageData = ctx.createImageData(this.getWidth(), this.getHeight());
         for (let i = 0; i < imageData.data.byteLength; i += 4) {

--- a/src/reader.js
+++ b/src/reader.js
@@ -1,0 +1,11 @@
+/**
+ * Reader-only entry point for consumers that decode cache data without using
+ * exporters or sprite rendering integrations.
+ */
+import RSCache from "./cacheReader/RSCache.js";
+import IndexType from "./cacheReader/cacheTypes/IndexType.js";
+import ConfigType from "./cacheReader/cacheTypes/ConfigType.js";
+import ModelGroup from "./cacheReader/helpers/ModelGroup.js";
+import { ModelDefinition } from "./cacheReader/loaders/ModelLoader.js";
+
+export { RSCache, IndexType, ConfigType, ModelGroup, ModelDefinition };


### PR DESCRIPTION
Expose `osrscachereader/reader` for decoding the cache in a node without requiring `canvas`. 

Use case is to import osrscachereader into the OSRS sim SDK without needing additional dependencies. The catch is you can't render sprites, but that's ok